### PR TITLE
Add flags to `shipthis game ship` for platform selection, skipping publish, and custom download filename

### DIFF
--- a/src/commands/game/build/download.tsx
+++ b/src/commands/game/build/download.tsx
@@ -5,8 +5,7 @@ import * as fs from 'fs'
 import {BaseGameCommand} from '@cli/baseCommands/index.js'
 
 import {Command, RunWithSpinner} from '@cli/components/index.js'
-import {getBuild} from '@cli/api/index.js'
-import axios from 'axios'
+import {downloadBuildById} from '@cli/api/index.js'
 
 export default class GameBuildDownload extends BaseGameCommand<typeof GameBuildDownload> {
   static override args = {
@@ -38,19 +37,7 @@ export default class GameBuildDownload extends BaseGameCommand<typeof GameBuildD
 
     const executeMethod = async () => {
       const game = await this.getGame()
-      const build = await getBuild(game.id, build_id)
-      const url = build.url
-      const writer = fs.createWriteStream(file)
-      const response = await axios({
-        url,
-        method: 'GET',
-        responseType: 'stream',
-      })
-      response.data.pipe(writer)
-      return new Promise((resolve, reject) => {
-        writer.on('finish', resolve)
-        writer.on('error', reject)
-      })
+      await downloadBuildById(game.id, build_id, file)
     }
 
     const handleComplete = async () => process.exit(0)

--- a/src/commands/game/ship.tsx
+++ b/src/commands/game/ship.tsx
@@ -1,23 +1,60 @@
-import {BaseGameCommand} from '@cli/baseCommands/baseGameCommand.js'
-
-import {CommandGame, Ship} from '@cli/components/index.js'
+import {Flags} from '@oclif/core'
 import {render} from 'ink'
+
+import {BaseGameCommand} from '@cli/baseCommands/baseGameCommand.js'
+import {CommandGame, Ship} from '@cli/components/index.js'
+import {getErrorMessage} from '@cli/utils/errors.js'
+import {Job} from '@cli/types/api.js'
+import {downloadBuildById} from '@cli/api/index.js'
 
 export default class GameShip extends BaseGameCommand<typeof GameShip> {
   static override args = {}
 
+  static override flags = {
+    ...BaseGameCommand.flags,
+    platform: Flags.string({
+      description: 'The platform to ship the game to. This can be "android" or "ios"',
+      required: false,
+      options: ['android', 'ios'],
+    }),
+    skipPublish: Flags.boolean({
+      description: 'Skip the publish step',
+      required: false,
+      default: false,
+    }),
+    download: Flags.string({
+      description: 'Download the build artifact to the specified file',
+      required: false,
+      dependsOn: ['platform'],
+    }),
+  }
+
   static override description = 'Builds the app (for all platforms with valid credentials) and ships it to the stores.'
 
-  static override examples = ['<%= config.bin %> <%= command.id %>']
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --platform ios',
+    '<%= config.bin %> <%= command.id %> --platform android --skipPublish',
+    '<%= config.bin %> <%= command.id %> --platform android --download output.aab',
+  ]
 
   public async run(): Promise<void> {
     await this.ensureWeAreInAProjectDir()
+    const gameId = await this.getGameId()
+    if (!gameId) {
+      this.error('No game ID found')
+    }
 
-    const handleComplete = () => process.exit(0)
+    const handleComplete = async (jobs: Job[]) => {
+      if (this.flags.download) {
+        // this only runs with the platform flag - so only one job
+        await downloadBuildById(gameId, `${jobs[0]?.build?.id}`, this.flags.download)
+      }
+      process.exit(0)
+    }
+
     const handleError = (e: Error) => {
-      // The ship component shows the error - we just fail
-      // TODO: specific error codes?
-      process.exit(1)
+      this.error(getErrorMessage(e))
     }
 
     render(

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -10,7 +10,7 @@ import {getShortAuthRequiredUrl} from '@cli/api/index.js'
 import {WEB_URL} from '@cli/constants/config.js'
 
 interface Props {
-  onComplete: () => void
+  onComplete: (completedJobs: Job[]) => void
   onError: (error: any) => void
 }
 
@@ -21,6 +21,7 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
 
   const [jobs, setJobs] = useState<Job[] | null>(null)
   const [failedJobs, setFailedJobs] = useState<Job[]>([])
+  const [successJobs, setSuccessJobs] = useState<Job[]>([])
 
   const [shipLog, setShipLog] = useState<string>('') // message shown as we prepare the shipping
   const [showLog, setShowLog] = useState<boolean>(false)
@@ -53,6 +54,8 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
   })
 
   const handleJobComplete = (job: Job) => {
+    // Add the job to the list of completed jobs
+    setSuccessJobs([...successJobs, job])
     // Remove the job from the list
     const newJobs = (jobs || []).filter((prevJob) => prevJob.id !== job.id)
     setJobs(newJobs)
@@ -71,7 +74,7 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
   useEffect(() => {
     if (!isComplete) return
     setTimeout(() => {
-      failedJobs.length === 0 ? onComplete() : onError('One or more jobs failed')
+      failedJobs.length === 0 ? onComplete(successJobs) : onError('One or more jobs failed')
     }, 500)
   }, [isComplete])
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -93,7 +93,10 @@ export enum JobStatus {
   FAILED = 'FAILED',
 }
 
-export type JobDetails = ProjectDetails & UploadDetails
+export type JobDetails = ProjectDetails &
+  UploadDetails & {
+    skipPublish?: boolean // If true, don't publish the build to the store
+  }
 
 export interface Job {
   id: string

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,30 @@
+import Axios from 'axios'
+
+export function isNetworkError(exception: any) {
+  if (!Axios.isAxiosError(exception)) return false
+  return ['ECONNABORTED', 'ERR_NETWORK'].includes(`${exception.code}`)
+}
+
+// Util to extract API error messages if present
+export function getErrorMessage(error: any) {
+  try {
+    if (isNetworkError(error)) {
+      return 'Please check your internet connection.'
+    }
+
+    const data = error?.response?.data
+    // Zod errors from the backend are an array
+    const apiValidation = Array.isArray(data)
+      ? data.map((r) => ('message' in r ? `Error - ${r.message}` : r.toString())).join(' ')
+      : ''
+
+    const apiErr = error?.response?.data?.error || ''
+    const apiMsg = `${apiErr}${apiValidation ? ' ' + apiValidation : ''}`
+    if (apiMsg.length === 0) {
+      return 'message' in error ? error.message : error.toString()
+    }
+    return apiMsg
+  } catch {
+    return error ? error.toString() : 'Error'
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,13 +7,14 @@ import {fileURLToPath} from 'node:url'
 
 import {JobStage, JobStatus, LogLevel, Platform, ScalarDict} from '@cli/types'
 
-export * from './hooks/index.js'
-export * from './query/index.js'
 export * from './dates.js'
 export * from './dictionary.js'
+export * from './errors.js'
 export * from './git.js'
 export * from './godot.js'
 export * from './help.js'
+export * from './hooks/index.js'
+export * from './query/index.js'
 
 /**
  * Works the same way that git short commits are generated.

--- a/src/utils/query/useShip.ts
+++ b/src/utils/query/useShip.ts
@@ -8,7 +8,7 @@ import {useMutation} from '@tanstack/react-query'
 import {DEFAULT_SHIPPED_FILES_GLOBS, DEFAULT_IGNORED_FILES_GLOBS, cacheKeys} from '@cli/constants/index.js'
 import {getCWDGitInfo, getFileHash, queryClient} from '@cli/utils/index.js'
 import {getNewUploadTicket, startJobsFromUpload} from '@cli/api/index.js'
-import {Job, ProjectConfig, UploadDetails} from '@cli/types'
+import {Job, Platform, ProjectConfig, UploadDetails} from '@cli/types'
 import {BaseCommand} from '@cli/baseCommands/index.js'
 
 // Takes the current command so we can get the project config
@@ -16,6 +16,12 @@ import {BaseCommand} from '@cli/baseCommands/index.js'
 interface ShipOptions {
   command: BaseCommand<any>
   log?: (message: string) => void
+}
+
+type ShipGameFlags = {
+  platform?: 'android' | 'ios'
+  skipPublish?: boolean
+  download?: string
 }
 
 export async function ship({command, log = () => {}}: ShipOptions): Promise<Job[]> {
@@ -73,7 +79,16 @@ export async function ship({command, log = () => {}}: ShipOptions): Promise<Job[
   }
 
   log('Starting jobs from upload...')
-  const jobs = await startJobsFromUpload(uploadTicket.id, uploadDetails)
+
+  const commandFlags = command.getFlags() as ShipGameFlags
+
+  const startJobsOptions = {
+    ...uploadDetails,
+    skipPublish: commandFlags.skipPublish,
+    platform: commandFlags.platform?.toUpperCase() as Platform,
+  }
+
+  const jobs = await startJobsFromUpload(uploadTicket.id, startJobsOptions)
 
   log('Cleaning up temporary zip file...')
   fs.unlinkSync(tmpZipFile)


### PR DESCRIPTION
Introducing new flags to the `shipthis game ship` command:

- `--platform` – Specify the target platform (`ios` or `android`)
- `--skipPublish` – Prevents publishing to TestFlight or Google Play after build
- `--download <filename>` – Downloads the built artifact (e.g., `game.aab`) to the specified filename

