### PR TITLE
Implementing `--downloadAPK` and adapting models for Job and Build

### DIFF
--- a/src/components/JobStatusTable.tsx
+++ b/src/components/JobStatusTable.tsx
@@ -3,7 +3,7 @@ import {Box, Text} from 'ink'
 import {DateTime} from 'luxon'
 import Spinner from 'ink-spinner'
 
-import {getBuildSummary, getJobStatusColor, getJobSummary, getStageColor} from '@cli/utils/index.js'
+import {getJobStatusColor, getJobSummary, getStageColor} from '@cli/utils/index.js'
 import {Job, JobStatus} from '@cli/types'
 import {useJobWatching} from '@cli/utils/hooks/index.js'
 import {Title} from './common/Title.js'
@@ -45,7 +45,6 @@ export const JobStatusTable = ({jobId, projectId, isWatching, onJobUpdate}: JobS
 
   const isJobInProgress = job && ![JobStatus.COMPLETED, JobStatus.FAILED].includes(job.status)
   const summary = job ? getJobSummary(job, time) : null
-  const buildSummary = job && job.build ? getBuildSummary(job.build) : null
 
   return (
     <Box flexDirection="row">
@@ -75,17 +74,6 @@ export const JobStatusTable = ({jobId, projectId, isWatching, onJobUpdate}: JobS
           </Box>
         )}
       </Box>
-      {buildSummary && (
-        <Box flexDirection="column" marginBottom={1} marginLeft={3} borderStyle="single" padding={1}>
-          <Title>Build Details</Title>
-          <Box flexDirection="column" marginLeft={2}>
-            <StatusRow label="ID" value={buildSummary.id} />
-            <StatusRow label="Platform" value={buildSummary.platform} />
-            <StatusRow label="Type" value={buildSummary.type} />
-            <StatusRow label="CMD" value={buildSummary.cmd} />
-          </Box>
-        </Box>
-      )}
     </Box>
   )
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -107,7 +107,7 @@ export interface Job {
   createdAt: DateTime
   updatedAt: DateTime
   details: JobDetails
-  build?: Build
+  builds?: Build[]
 }
 
 export enum JobStage {
@@ -169,6 +169,12 @@ export interface ProjectCredential extends UserCredential {
   identifier: string
 }
 
+export enum BuildType {
+  IPA = 'IPA',
+  APK = 'APK',
+  AAB = 'AAB',
+}
+
 export interface Build {
   id: string
   jobId: Job['id']
@@ -181,6 +187,7 @@ export interface Build {
   // When we display the list of builds we want to show some details and
   // we don't want to make a circular reference to the job
   jobDetails: JobDetails
+  buildType: BuildType
 }
 
 // URL params received by the Google Redirect destination

--- a/src/utils/query/useBuilds.ts
+++ b/src/utils/query/useBuilds.ts
@@ -36,12 +36,14 @@ export async function queryBuilds({projectId, ...pageAndSortParams}: BuildsQuery
 
 // How we typically display a project build
 export function getBuildSummary(build: Build): ScalarDict {
-  const filename = build.platform == Platform.IOS ? 'output.ipa' : 'output.aab' // TODO
+  const buildType = build.buildType || (build.platform == Platform.IOS ? 'IPA' : 'AAB')
+  const filename = `game.${buildType.toLowerCase()}`
+
   return {
     id: getShortUUID(build.id),
-    ...getJobDetailsSummary(build.jobDetails),
-    platform: getPlatformName(build.platform),
     jobId: getShortUUID(build.jobId),
+    ...getJobDetailsSummary(build.jobDetails),
+    type: `${getPlatformName(build.platform)} ${buildType}`,
     createdAt: getShortDateTime(build.createdAt),
     cmd: `shipthis game build download ${getShortUUID(build.id)} ${filename}`,
   }

--- a/src/utils/query/useJob.ts
+++ b/src/utils/query/useJob.ts
@@ -15,14 +15,13 @@ export interface JobQueryProps {
 export function getJobDetailsSummary(jobDetails: JobDetails): ScalarDict {
   const semanticVersion = jobDetails?.semanticVersion || 'N/A'
   const buildNumber = jobDetails?.buildNumber || 'N/A'
-  const gitCommit = jobDetails?.gitCommitHash ? getShortUUID(jobDetails?.gitCommitHash) : 'N/A'
-  const gitBranch = jobDetails?.gitBranch || 'N/A'
+  const gitCommit = jobDetails?.gitCommitHash ? getShortUUID(jobDetails?.gitCommitHash) : ''
+  const gitBranch = jobDetails?.gitBranch || ''
   return {
     version: `${semanticVersion} (${buildNumber})`,
-    gitInfo: `${gitCommit} (${gitBranch})`,
+    gitInfo: gitCommit ? `${gitCommit} (${gitBranch})` : '',
   }
 }
-
 
 export function getJobSummary(job: Job, timeNow: DateTime): ScalarDict {
   const inProgress = ![JobStatus.COMPLETED, JobStatus.FAILED].includes(job.status)


### PR DESCRIPTION
- Updated the model for Job to have multiple builds
- Added `buildType` to Build model to identify APK and AAB
- Added downloadAPK flag to the `shipthis game ship` command
- Updated the `shipthis game build list` output to show the buildType
- Revised the `shipthis game job status` output

TODO:
- Update docs to add to the other issue of outstanding doc updates?