### PR TITLE
fix: make any doc changes as pr rather than auto-committing

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -43,6 +43,10 @@ jobs:
           npm run readme
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: 'chore: update docs'
+          title: 'chore: update docs'
+          body: 'Automatically generated as missing docs in `main` branch'
       - name: Create Github Release
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
         if: ${{ steps.version-check.outputs.skipped == 'false' }}

--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -40,11 +41,8 @@ jobs:
         run: |
           npm install
           npm run readme
-          if [ -n "$(git status --porcelain)" ]; then
-            git add .
-            git commit -am "chore: update docs"
-            git push -u origin ${{ github.ref_name }}
-          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
       - name: Create Github Release
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
         if: ${{ steps.version-check.outputs.skipped == 'false' }}


### PR DESCRIPTION
On second thought it is a bit risky to just let the pipeline commit any changes in the working directory after the docs generation run, so this update turns the changes into a PR instead so that we can review it and merge if happy.