### PR TITLE
feat: add auto-generated release notes to releases

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -68,6 +68,7 @@ jobs:
           tag: ${{ steps.version-check.outputs.tag }}
           commit: ${{ github.ref_name }}
           skipIfReleaseExists: true
+          generateReleaseNotes: true
       - name: Publish to npm
         if: ${{ steps.version-check.outputs.skipped == 'false' && !env.ACT }}
         uses: JS-DevTools/npm-publish@v3


### PR DESCRIPTION
The `generateReleaseNotes` flag uses the github API to generate release notes so is the same as enabling it via the `release.yml`.

The release note messages are based on the PR titles.

Closes #23 