### PR TITLE
Resolves #13 - Directly tailing the build logs. 

### DIFF
--- a/src/commands/game/ship.tsx
+++ b/src/commands/game/ship.tsx
@@ -32,6 +32,12 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
       required: false,
       dependsOn: ['platform'],
     }),
+    follow: Flags.boolean({
+      description: 'Follow the job logs in real-time. Requires --platform to be specified.',
+      required: false,
+      default: false,
+      dependsOn: ['platform'],
+    }),
   }
 
   static override description = 'Builds the app (for all platforms with valid credentials) and ships it to the stores.'
@@ -40,7 +46,8 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --platform ios',
     '<%= config.bin %> <%= command.id %> --platform android --skipPublish',
-    '<%= config.bin %> <%= command.id %> --platform android --download output.aab',
+    '<%= config.bin %> <%= command.id %> --platform android --download game.aab',
+    '<%= config.bin %> <%= command.id %> --platform android --follow --downloadAPK game.apk',
   ]
 
   public async run(): Promise<void> {

--- a/src/commands/game/ship.tsx
+++ b/src/commands/game/ship.tsx
@@ -35,7 +35,6 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
     follow: Flags.boolean({
       description: 'Follow the job logs in real-time. Requires --platform to be specified.',
       required: false,
-      default: false,
       dependsOn: ['platform'],
     }),
   }

--- a/src/components/JobFollow.tsx
+++ b/src/components/JobFollow.tsx
@@ -1,0 +1,26 @@
+import {Job, JobLogEntry, LogLevel} from '@cli/types/api.js'
+import {useJobWatching} from '@cli/utils/index.js'
+
+interface JobFollowProps {
+  projectId: string
+  jobId: string
+  onComplete?: (job: Job) => void
+  onFailure?: (job: Job) => void
+}
+
+// Outputs job logs to stdout/stderr as they come in
+export const JobFollow = ({projectId, jobId, onComplete, onFailure}: JobFollowProps) => {
+  useJobWatching({
+    projectId,
+    jobId,
+    isWatching: true,
+    onNewLogEntry: (logEntry: JobLogEntry) => {
+      if (logEntry.level == LogLevel.ERROR) console.error(logEntry.message)
+      else console.log(logEntry.message)
+    },
+    onComplete,
+    onFailure,
+  })
+
+  return null
+}

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -3,9 +3,17 @@ import {useContext, useEffect, useState} from 'react'
 import {Text, Box, useInput} from 'ink'
 import open from 'open'
 
-import {CommandContext, GameContext, JobLogTail, JobProgress, JobStatusTable, Markdown} from '@cli/components/index.js'
+import {
+  CommandContext,
+  GameContext,
+  JobLogTail,
+  JobProgress,
+  JobStatusTable,
+  Markdown,
+  JobFollow,
+} from '@cli/components/index.js'
 import {getShortUUID, useShip} from '@cli/utils/index.js'
-import {Job} from '@cli/types/index.js'
+import {Job, ShipGameFlags} from '@cli/types/index.js'
 import {getShortAuthRequiredUrl} from '@cli/api/index.js'
 import {WEB_URL} from '@cli/constants/config.js'
 
@@ -16,6 +24,7 @@ interface Props {
 
 export const Ship = ({onComplete, onError}: Props): JSX.Element => {
   const {command} = useContext(CommandContext)
+  const flags = command && (command.getFlags() as ShipGameFlags)
   const {gameId} = useContext(GameContext)
   const shipMutation = useShip()
 
@@ -79,6 +88,16 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
   }, [isComplete])
 
   if (!gameId) return <></>
+
+  if (flags?.follow) {
+    if (jobs && jobs.length > 0) {
+      return (
+        <JobFollow projectId={gameId} jobId={jobs[0].id} onComplete={handleJobComplete} onFailure={handleJobFailure} />
+      )
+    }
+
+    return <></>
+  }
 
   return (
     <Box flexDirection="column">

--- a/src/components/common/JobProgress.tsx
+++ b/src/components/common/JobProgress.tsx
@@ -1,36 +1,20 @@
-import {useRef} from 'react'
-
-import {Job, JobStatus} from '@cli/types/api.js'
+import {Job} from '@cli/types/api.js'
 import {getPlatformName, useJobWatching} from '@cli/utils/index.js'
 import {ProgressSpinner} from '@cli/components/index.js'
 
 interface Props {
   job: Job
-  onComplete: (j: Job) => void
-  onFailure: (j: Job) => void
+  onComplete?: (j: Job) => void
+  onFailure?: (j: Job) => void
 }
 
 export const JobProgress = (props: Props) => {
-  const prevJobStatus = useRef<JobStatus>(props.job.status)
-
-  const handleJobUpdate = (job: Job) => {
-    const completed = [JobStatus.COMPLETED, JobStatus.FAILED]
-    const wasRunning = !completed.includes(prevJobStatus.current)
-    if (completed.includes(job.status) && wasRunning) {
-      if (job.status === JobStatus.FAILED) {
-        props.onFailure(job)
-      } else {
-        props.onComplete(job)
-      }
-    }
-    prevJobStatus.current = job.status
-  }
-
   const {progress} = useJobWatching({
     projectId: props.job.project.id,
     jobId: props.job.id,
     isWatching: true,
-    onJobUpdate: handleJobUpdate,
+    onComplete: props.onComplete,
+    onFailure: props.onFailure,
   })
 
   const label = `${getPlatformName(props.job.type)} build progress...`

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -5,6 +5,7 @@ export * from './context/index.js'
 export * from './wrappers/index.js'
 
 export * from './BuildsTable.js'
+export * from './JobFollow.js'
 export * from './JobLogTail.js'
 export * from './JobStatusTable.js'
 export * from './ProjectCredentialsTable.js'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,5 +15,13 @@ export interface ProjectConfig {
   ignoredFilesGlobs?: string[]
 }
 
+export type ShipGameFlags = {
+  platform?: 'android' | 'ios'
+  skipPublish?: boolean
+  download?: string
+  downloadAPK?: string
+  follow?: boolean
+}
+
 export * from './api.js'
 export * from './request.js'

--- a/src/utils/hooks/useJobWatching.ts
+++ b/src/utils/hooks/useJobWatching.ts
@@ -1,6 +1,6 @@
-import {Job, JobLogEntry, JobStage} from '@cli/types'
+import {Job, JobLogEntry, JobStage, JobStatus} from '@cli/types'
 import {useJob} from '@cli/utils/query/useJob.js'
-import {useEffect, useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 import {useWebSocket, WebSocketListener} from './useWebSocket.js'
 import {castJobDates, castObjectDates} from '@cli/utils/dates.js'
 
@@ -9,6 +9,9 @@ export interface JobWatchingProps {
   jobId: string
   isWatching: boolean
   onJobUpdate?: (job: Job) => void
+  onComplete?: (j: Job) => void
+  onFailure?: (j: Job) => void
+  onNewLogEntry?: (logEntry: JobLogEntry) => void
 }
 
 export interface JobWatchingResult {
@@ -19,9 +22,32 @@ export interface JobWatchingResult {
 }
 
 // Like useJob but also listens for job updates via websocket
-export function useJobWatching({projectId, jobId, isWatching, onJobUpdate}: JobWatchingProps): JobWatchingResult {
+export function useJobWatching({
+  projectId,
+  jobId,
+  isWatching,
+  onJobUpdate,
+  onFailure,
+  onComplete,
+  onNewLogEntry,
+}: JobWatchingProps): JobWatchingResult {
   const [websocketJob, setWebsocketJob] = useState<Job | null>(null)
   const [mostRecentLog, setMostRecentLog] = useState<JobLogEntry | null>(null)
+
+  const prevJobStatus = useRef<JobStatus>(JobStatus.PENDING)
+
+  const handleJobUpdate = (job: Job) => {
+    const completed = [JobStatus.COMPLETED, JobStatus.FAILED]
+    const wasRunning = !completed.includes(prevJobStatus.current)
+    if (completed.includes(job.status) && wasRunning) {
+      if (job.status === JobStatus.FAILED) {
+        onFailure && onFailure(job)
+      } else {
+        onComplete && onComplete(job)
+      }
+    }
+    prevJobStatus.current = job.status
+  }
 
   const jobStatusListener: WebSocketListener = {
     getPattern: () => [`project.${projectId}:job:created`, `project.${projectId}:job:updated`],
@@ -29,6 +55,7 @@ export function useJobWatching({projectId, jobId, isWatching, onJobUpdate}: JobW
       if (rawJob.id !== jobId) return
       const job = castJobDates(rawJob)
       setWebsocketJob(job)
+      handleJobUpdate(job)
       if (onJobUpdate) onJobUpdate(job)
     },
   }
@@ -37,6 +64,7 @@ export function useJobWatching({projectId, jobId, isWatching, onJobUpdate}: JobW
     getPattern: () => `project.${projectId}:job.${jobId}:log`,
     eventHandler: async (pattern: string, rawLogEntry: any) => {
       const logEntry = castObjectDates<JobLogEntry>(rawLogEntry, ['sentAt', 'createdAt'])
+      if (onNewLogEntry) onNewLogEntry(logEntry)
       setMostRecentLog(logEntry)
     },
   }

--- a/src/utils/query/useShip.ts
+++ b/src/utils/query/useShip.ts
@@ -8,7 +8,7 @@ import {useMutation} from '@tanstack/react-query'
 import {DEFAULT_SHIPPED_FILES_GLOBS, DEFAULT_IGNORED_FILES_GLOBS, cacheKeys} from '@cli/constants/index.js'
 import {getCWDGitInfo, getFileHash, queryClient} from '@cli/utils/index.js'
 import {getNewUploadTicket, startJobsFromUpload} from '@cli/api/index.js'
-import {Job, Platform, ProjectConfig, UploadDetails} from '@cli/types'
+import {Job, Platform, ProjectConfig, ShipGameFlags, UploadDetails} from '@cli/types'
 import {BaseCommand} from '@cli/baseCommands/index.js'
 
 // Takes the current command so we can get the project config
@@ -16,12 +16,6 @@ import {BaseCommand} from '@cli/baseCommands/index.js'
 interface ShipOptions {
   command: BaseCommand<any>
   log?: (message: string) => void
-}
-
-type ShipGameFlags = {
-  platform?: 'android' | 'ios'
-  skipPublish?: boolean
-  download?: string
 }
 
 export async function ship({command, log = () => {}}: ShipOptions): Promise<Job[]> {


### PR DESCRIPTION
- Added a `--follow` flag to the `shipthis game ship` command
- This flag is dependent on the `--platform` flag as we can only follow one job
- The changes affect a few things which will need testing:
  - `shipthis game ship`
  - `shipthis game ship --follow`
  - `shipthis game job list`
  - `shipthis game job status`
  - `shipthis game job status --follow`
  - `shipthis game wizard android` - need to check the initial build progress works