### PR TITLE
Fix race condition where build asset wasn't immediately available on job completion

### DIFF
--- a/src/commands/game/ship.tsx
+++ b/src/commands/game/ship.tsx
@@ -4,8 +4,8 @@ import {render} from 'ink'
 import {BaseGameCommand} from '@cli/baseCommands/baseGameCommand.js'
 import {CommandGame, Ship} from '@cli/components/index.js'
 import {getErrorMessage} from '@cli/utils/errors.js'
-import {Job} from '@cli/types/api.js'
-import {downloadBuildById} from '@cli/api/index.js'
+import {Build, Job} from '@cli/types/api.js'
+import {downloadBuildById, getJob} from '@cli/api/index.js'
 
 export default class GameShip extends BaseGameCommand<typeof GameShip> {
   static override args = {}
@@ -56,16 +56,26 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
       this.error('No game ID found')
     }
 
-    const handleComplete = async ([job]: Job[]) => {
+    const MAX_RETRIES = 3
+    const RETRY_DELAY_MS = 5000
+
+    const handleComplete = async ([originalJob]: Job[]) => {
       if (!this.flags.download && !this.flags.downloadAPK) return process.exit(0)
 
-      const builds = job.builds ?? []
-      if (builds.length === 0) this.error('No builds found for this job')
+      let job: Job | null = null
+
+      for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        job = await getJob(originalJob.id, gameId)
+        if (job.builds && job.builds.length > 0) break
+        if (attempt < MAX_RETRIES) await new Promise((res) => setTimeout(res, RETRY_DELAY_MS))
+      }
+
+      if (!job?.builds || job.builds.length === 0) this.error('No builds found for this job after multiple attempts')
 
       const platform = this.flags.platform
       const type = platform === 'android' ? (this.flags.downloadAPK ? 'APK' : 'AAB') : 'IPA'
 
-      const build = builds.find((b) => b.buildType === type)
+      const build = job.builds.find((b) => b.buildType === type)
       if (!build) this.error(`No build found for type ${type}`)
 
       const filename = this.flags.download || this.flags.downloadAPK


### PR DESCRIPTION
Resolves an issue with the `--download` and `--downloadAPK` flags.

When a job completes, the associated build asset may not be immediately available on the backend due to asynchronous post-processing.

This update adds retry logic when attempting to download the build, ensuring the asset is retrieved once it's ready.