### PR TITLE
Showing correct text on ship-success

### DIFF
--- a/assets/markdown/ship-success.md
+++ b/assets/markdown/ship-success.md
@@ -1,6 +1,6 @@
 # 🚀 Shipped
 
-**Your game has been successfully built and published.**
+**Your game has been successfully built${if wasPublished} and published${endif}.**
 
 ## Next Steps
 

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -129,6 +129,7 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
             <Markdown
               filename="ship-success.md"
               templateVars={{
+                wasPublished: flags?.skipPublish ? false : true,
                 gameBuildsUrl: `${WEB_URL}games/${getShortUUID(gameId)}/builds`,
               }}
             />


### PR DESCRIPTION
This is a fix for #26 

We are not using a templating library here - it is done with some hard to maintain regexes. We may want to consider using a dedicated templating lib or researching what the marked-terminal lib offers.

This is done but not perfect.