### PR TITLE
Better handling for incorrectly configured games and recommended commands to run

### DIFF
--- a/src/commands/apple/status.tsx
+++ b/src/commands/apple/status.tsx
@@ -38,7 +38,7 @@ export default class AppleStatus extends BaseAuthenticatedCommand<typeof AppleSt
 
     let steps = []
 
-    if (!isAuthenticatedOnApple) steps.push('$ shipthis apple login')
+    if (!isAuthenticatedOnApple) steps.push('shipthis apple login')
 
     render(
       <Command command={this}>

--- a/src/commands/game/android/status.tsx
+++ b/src/commands/game/android/status.tsx
@@ -34,7 +34,7 @@ export default class GameAndroidStatus extends BaseGameCommand<typeof GameAndroi
       (platformStatus.hasBundleSet == false ||
         platformStatus.hasApiKeyForPlatform == false ||
         platformStatus.hasCredentialsForPlatform == false) &&
-        '$ shipthis game android setup',
+        'shipthis game wizard android',
     ].filter(Boolean) as string[]
 
     const progressToStatuses = (progress: ProjectPlatformProgress) => {

--- a/src/commands/game/ios/status.tsx
+++ b/src/commands/game/ios/status.tsx
@@ -34,7 +34,7 @@ export default class GameIosStatus extends BaseGameCommand<typeof GameIosStatus>
     }
     // TODO: what if they have not yet connected to apple?
     // TODO: what do do if they have credentials?
-    const steps = [iosPlatformStatus.hasBundleSet == false && '$ shipthis game ios app create'].filter(
+    const steps = [iosPlatformStatus.hasBundleSet == false && 'shipthis game ios app create'].filter(
       Boolean,
     ) as string[]
 

--- a/src/commands/game/list.tsx
+++ b/src/commands/game/list.tsx
@@ -49,10 +49,16 @@ export default class GameList extends BaseAuthenticatedCommand<typeof GameList> 
 
     render(
       <Command command={this}>
-        {gameListResponse.data.length === 0 && params.pageNumber == 0 && (
-          <Text>No games found. Create one now with $ shipthis game wizard</Text>
+        {data.length === 0 && params.pageNumber == 0 && (
+          <Box flexDirection="column">
+            <Text>No games found. Create one now with:</Text>
+            <Box flexDirection="column" marginLeft={2} marginTop={1}>
+              <Text>shipthis game wizard android</Text>
+              <Text>shipthis game wizard ios</Text>
+            </Box>
+          </Box>
         )}
-        {gameListResponse.data.length > 0 && <Table data={data} />}
+        {data.length > 0 && <Table data={data} />}
         {gameListResponse.pageCount > 1 && (
           <Box marginTop={1} flexDirection="column">
             <Text>{`Showing page ${flags.pageNumber + 1} of ${gameListResponse.pageCount}.`}</Text>

--- a/src/commands/game/status.tsx
+++ b/src/commands/game/status.tsx
@@ -12,16 +12,16 @@ function getSteps(platform: Platform, progress: ProjectPlatformProgress | null) 
   switch (platform) {
     case Platform.ANDROID:
       return [
-        !progress.hasCredentialsForPlatform && '$ shipthis game android keyStore create',
-        !progress.hasApiKeyForPlatform && '$ shipthis game android apiKey create',
-        progress.hasCredentialsForPlatform && progress.hasApiKeyForPlatform && '$ shipthis game ship',
+        !progress.hasCredentialsForPlatform && 'shipthis game android keyStore create',
+        !progress.hasApiKeyForPlatform && 'shipthis game android apiKey create',
+        progress.hasCredentialsForPlatform && progress.hasApiKeyForPlatform && 'shipthis game ship',
       ].filter(Boolean) as string[]
 
     case Platform.IOS:
       return [
-        !progress.hasApiKeyForPlatform && '$ shipthis apple apiKey create',
-        !progress.hasCredentialsForPlatform && '$ shipthis game ios profile create',
-        progress.hasApiKeyForPlatform && progress.hasCredentialsForPlatform && '$ shipthis game ship',
+        !progress.hasApiKeyForPlatform && 'shipthis apple apiKey create',
+        !progress.hasCredentialsForPlatform && 'shipthis game ios profile create',
+        progress.hasApiKeyForPlatform && progress.hasCredentialsForPlatform && 'shipthis game ship',
       ].filter(Boolean) as string[]
 
     default:
@@ -62,6 +62,10 @@ export default class GameStatus extends BaseAuthenticatedCommand<typeof GameStat
     let steps: string[] = []
     if (hasConfiguredIos) steps = steps.concat(getSteps(Platform.IOS, statuses[Platform.IOS]))
     if (hasConfiguredAndroid) steps = steps.concat(getSteps(Platform.ANDROID, statuses[Platform.ANDROID]))
+
+    if (!hasConfiguredIos && !hasConfiguredAndroid) {
+      steps = steps.concat(['shipthis game wizard android', 'shipthis game wizard ios'])
+    }
 
     const progressToStatuses = (progress: ProjectPlatformProgress) => {
       // Remove the 'platform' key as we have titles

--- a/src/commands/status.tsx
+++ b/src/commands/status.tsx
@@ -24,11 +24,11 @@ export default class Status extends BaseCommand<typeof Status> {
 
     let steps = []
 
-    if (!isLoggedIn) steps.push('$ shipthis login --email my.email@address.nowhere')
+    if (!isLoggedIn) steps.push('shipthis login --email my.email@address.nowhere')
     if (!isGodotGame) steps.push('Run this command in a Godot project directory')
-    if (!isShipThisConfigured) steps.push('$ shipthis game wizard')
+    if (!isShipThisConfigured) steps.push('shipthis game wizard')
 
-    if (steps.length === 0) steps = ['$ shipthis game status']
+    if (steps.length === 0) steps = ['shipthis game status']
 
     const statusProps = {
       title: 'Status',


### PR DESCRIPTION
## This should resolve #31

- Removed `$ ` prefix from example commands - the dollar sign is a Linux-only convention and may be confusing.
- Improved empty state for `shipthis game list`, including a correct example command.
- Fixed output of `shipthis game status` when no platforms are configured.
- Added a check for configured platforms before zipping in `useShip`.
