### PR TITLE
Fixing issue where the Google privacy text was not shown on tall sceens

### DIFF
--- a/src/components/android/ConnectGoogle/index.tsx
+++ b/src/components/android/ConnectGoogle/index.tsx
@@ -3,7 +3,7 @@ import open from 'open'
 import {useContext, useState} from 'react'
 
 import {WEB_URL} from '@cli/constants/index.js'
-import {useGoogleStatusWatching, useResponsive} from '@cli/utils/index.js'
+import {useGoogleStatusWatching} from '@cli/utils/index.js'
 import {GoogleStatusResponse} from '@cli/types/api.js'
 import {GameContext, Markdown, StepProps} from '@cli/components/index.js'
 
@@ -23,8 +23,8 @@ interface ConnectWithGameProps extends Props {
 }
 
 const ConnectForGame = ({onComplete, onError, helpPage, gameId, ...boxProps}: ConnectWithGameProps): JSX.Element => {
-  const {isTall} = useResponsive()
-  const [showQRCode, setShowQRCode] = useState(isTall)
+
+  const [showQRCode, setShowQRCode] = useState(false)
 
   useGoogleStatusWatching({
     projectId: gameId,


### PR DESCRIPTION
We were linking the `showQRCode` to the screen being tall.

This meant that the **privacy-notification.md** text was not shown to these users.

We must show the privacy text before users connect.