### PR TITLE
Fixing issue when export_presets is an empty file

### DIFF
--- a/src/utils/godot.ts
+++ b/src/utils/godot.ts
@@ -116,7 +116,7 @@ export function getGodotExportPresets(platform: Platform) {
     const exportPresetsContent = fs.readFileSync(exportPresetsPath, 'utf8')
     const exportPresetsIni = parse(exportPresetsContent)
     // Find the preset with the same name in the existing config
-    const presetIndexes = Object.keys(exportPresetsIni.preset)
+    const presetIndexes = Object.keys(exportPresetsIni.preset || {})
     const presetIndex = presetIndexes.find((index) => {
       const current = exportPresetsIni.preset[index]
       return `${current.name}`.toUpperCase() === platform


### PR DESCRIPTION
Tiny fix - handling situation where the export_presets.cfg file is empty - we have it like this during the automated testing.

This was breaking the command `shipthis game ios app status`