### PR TITLE
Additional debugging output when running `shipthis game ship --follow` 

### DIFF
--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -39,7 +39,8 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
   // Start the command on mount
   const handleStartOnMount = async () => {
     if (!command) throw new Error('No command in context')
-    const startedJobs = await shipMutation.mutateAsync({command, log: setShipLog})
+    const logFn = flags?.follow ? console.log : setShipLog
+    const startedJobs = await shipMutation.mutateAsync({command, log: logFn})
     setJobs(startedJobs)
   }
 

--- a/src/utils/query/useShip.ts
+++ b/src/utils/query/useShip.ts
@@ -105,6 +105,10 @@ export async function ship({command, log = () => {}, shipFlags}: ShipOptions): P
     throw new Error('No jobs were created. Please check your game configuration and try again.')
   }
 
+  if (finalFlags?.follow) {
+    log('Waiting for job to start...')
+  }
+
   return jobs
 }
 


### PR DESCRIPTION
## Description

This should resolve #50 

## What's changed

Previously we were swallowing the log messages made while the `useShip` mutation was running with the `--follow` flag. Now we are showing those messages and a `Waiting for job to start... ` message.

## Demo

```bash
david@sal9000:~/work/shipthis.cc/testing/automated/build/output/v4/ios$ shipthis game ship --platform ios --follow --skipPublish
Fetching game config...
Retrieving file globs...
Finding files to include in zip...
Found 45 files, adding to zip...
Creating zip file: /home/david/work/shipthis.cc/testing/automated/build/output/v4/ios/shipthis-7b338503-7291-4aef-b254-221449b1a2b1.zip
Reading zip file buffer...
Requesting upload ticket...
Uploading zip file...
Fetching Git info...
Computing file hash...
Starting jobs from upload...
Cleaning up temporary zip file...
Job submission complete.
Waiting for job to start...
```
