### PR TITLE
Showing current email address in `shipthis status` output

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -17,7 +17,7 @@ Displays the current overall status.
 
 ## Example
 
-[![asciicast](https://asciinema.org/a/GsqLxzyvFApORKUDfJl5DsNo7.svg)](https://asciinema.org/a/GsqLxzyvFApORKUDfJl5DsNo7)
+[![asciicast](https://asciinema.org/a/i5chSgJubWSXlAzjYdht98fLj.svg)](https://asciinema.org/a/i5chSgJubWSXlAzjYdht98fLj)
 
 ## Help Output
 

--- a/src/commands/status.tsx
+++ b/src/commands/status.tsx
@@ -4,6 +4,7 @@ import {BaseCommand} from '@cli/baseCommands/index.js'
 import {Command, NextSteps, StatusTable} from '@cli/components/index.js'
 import {AuthConfig} from '@cli/types'
 import {isCWDGitRepo, isCWDGodotGame} from '@cli/utils/index.js'
+import chalk from 'chalk'
 
 export default class Status extends BaseCommand<typeof Status> {
   static override args = {}
@@ -18,6 +19,7 @@ export default class Status extends BaseCommand<typeof Status> {
     const authConfig: AuthConfig = await this.getAuthConfig()
 
     const isLoggedIn = Boolean(authConfig.shipThisUser)
+    const email = authConfig.shipThisUser?.email
     const isGodotGame = isCWDGodotGame()
     const isShipThisConfigured = await this.hasProjectConfig()
     const isGitRepo = await isCWDGitRepo()
@@ -33,7 +35,7 @@ export default class Status extends BaseCommand<typeof Status> {
     if (steps.length === 0) steps = ['shipthis game status']
 
     const statuses: Record<string, boolean> = {}
-    statuses['Logged in'] = isLoggedIn
+    statuses[email ? `Logged in ${chalk.bold(email)}` : 'Logged in'] = isLoggedIn
     statuses['Godot project detected'] = isGodotGame
     statuses['ShipThis project configured'] = isShipThisConfigured
     statuses['Git repository detected (not required)'] = isGitRepo


### PR DESCRIPTION
## Description

This is to resolve #76 so that people can easily see which account they are using

## What's changed?

- If the user is logged in then the label for the "Logged In" row in the status table includes the user's email address in bold
- Made an asciinema recording of this and included this in the docs

## Demo

[![asciicast](https://asciinema.org/a/i5chSgJubWSXlAzjYdht98fLj.svg)](https://asciinema.org/a/i5chSgJubWSXlAzjYdht98fLj)

