### PR TITLE
feat: Checking for agreement (terms/privacy) changes and showing warning if so

### DIFF
--- a/assets/markdown/agreement-update.md.ejs
+++ b/assets/markdown/agreement-update.md.ejs
@@ -7,6 +7,6 @@ Read more: <%= agreement.url %>
 
 <% }); %>
 
-Hide this message by running: `shipthis login --acceptPolicy`
+Hide this message by running: `shipthis login --acceptAgreements`
 
 ---

--- a/assets/markdown/agreement-update.md.ejs
+++ b/assets/markdown/agreement-update.md.ejs
@@ -1,0 +1,12 @@
+# Warning - there are changes to our agreements:
+
+<% changes.forEach((agreement) => { %>
+## <%= agreement.agreementType === 'PRIVACY_POLICY' ? 'Privacy Policy' : 'Terms and Conditions' %> Update (<%= agreement.versionName %>)
+**<%= agreement.description %>**
+Read more: <%= agreement.url %>
+
+<% }); %>
+
+Hide this message by running: `shipthis login --acceptPolicy`
+
+---

--- a/docs/login.md
+++ b/docs/login.md
@@ -18,11 +18,13 @@ you can view details of your games.
 
 ```help
 USAGE
-  $ shipthis login [-f] [-e <value>]
+  $ shipthis login [-e <value>] [-f] [--acceptAgreements]
 
 FLAGS
-  -e, --email=<value>  Your email address
+  -e, --email=<value>     Your email address
   -f, --force
+      --acceptAgreements  Accept the current version of the agreements (terms &
+                          privacy).
 
 DESCRIPTION
   Authenticate - will create a new account if one does not exist.
@@ -31,4 +33,6 @@ EXAMPLES
   $ shipthis login
 
   $ shipthis login --force --email me@email.nowhere
+
+  $ shipthis login --acceptAgreements
 ```

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,6 +6,7 @@ import {v4 as uuid} from 'uuid'
 
 import {API_URL, WEB_URL} from '@cli/constants/index.js'
 import {
+  AgreementVersion,
   APIKey,
   APIKeyCreateRequest,
   APIKeyWithSecret,
@@ -20,6 +21,7 @@ import {
   ProjectDetails,
   ProjectPlatformProgress,
   Self,
+  TermsResponse,
   UploadDetails,
   UploadTicket,
 } from '@cli/types'
@@ -203,11 +205,24 @@ export async function getSelf(): Promise<Self> {
   return castObjectDates<Self>(data)
 }
 
-// Marks the current user as accepting the T&cs and privacy
+// Tells us the current agreement / terms status for the user
+export async function getTerms(): Promise<TermsResponse> {
+  const headers = getAuthedHeaders()
+  const opt = {headers}
+  const {data} = await axios.get(`${API_URL}/me/terms`, opt)
+  return {
+    // Any agreements which have changed since the user last accepted terms
+    changes: castArrayObjectDates<AgreementVersion>(data.changes),
+    // Current versions of any agreements
+    current: castArrayObjectDates<AgreementVersion>(data.current),
+  } as TermsResponse
+}
+
+// Marks the current user as accepting the current version of terms and privacy
 export async function acceptTerms(): Promise<Self> {
   const headers = getAuthedHeaders()
   const opt = {headers}
-  const {data} = await axios.post(`${API_URL}/me/acceptTerms`, {}, opt)
+  const {data} = await axios.post(`${API_URL}/me/terms`, {}, opt)
   return castObjectDates<Self>(data)
 }
 

--- a/src/baseCommands/baseAuthenticatedCommand.ts
+++ b/src/baseCommands/baseAuthenticatedCommand.ts
@@ -20,7 +20,7 @@ export abstract class BaseAuthenticatedCommand<T extends typeof Command> extends
     // hasAcceptedTerms is set on first POST to /me/terms
     const accepted = Boolean(self.details?.hasAcceptedTerms)
     if (!accepted) {
-      this.error('You must accept the terms and conditions. Please run `shipthis login --force` to re-authenticate', {
+      this.error('You must accept the agreements first. Please run `shipthis login --acceptAgreements` to do this.', {
         exit: 1,
       })
     }

--- a/src/components/common/Markdown.tsx
+++ b/src/components/common/Markdown.tsx
@@ -9,7 +9,7 @@ import {useEffect, useState} from 'react'
 
 interface Props extends TerminalRendererOptions {
   filename: string
-  templateVars?: Record<string, boolean | string>
+  templateVars?: any
 }
 
 const cleanHyperlinks = (input: string): string =>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -9,6 +9,8 @@ export type ScalarDict = {
 export interface UserDetails {
   hasAcceptedTerms?: boolean
   source?: string
+  termsAgreementVersionId?: AgreementVersion['id'];
+  privacyAgreementVersionId?: AgreementVersion['id'];
 }
 
 export interface Self {
@@ -247,4 +249,20 @@ export interface APIKeyWithSecret extends APIKey {
 export interface APIKeyCreateRequest {
   durationDays: number
   name: string
+}
+
+export interface AgreementVersion {
+  id: string
+  agreementType: string
+  versionName: string
+  description: string
+  isInitial: boolean
+  createdAt: DateTime
+  updatedAt: DateTime
+  path: string
+}
+
+export interface TermsResponse {
+  changes: AgreementVersion[]
+  current: AgreementVersion[]
 }


### PR DESCRIPTION
## Desciption

This is to resolve #79 

We check if there are policy changes for any "authenticated command" and display a warning.

## What's changed

- Check is done in src/baseCommands/baseAuthenticatedCommand.ts
- It does not prevent usage if the agreements have changed, just shows a warning
- Output comes before other output
- It should not interfere with other commands
- Added a new flag `--acceptAgreements` to the `shipthis login` command
- Login docs updated
 

## Demo

[![asciicast](https://asciinema.org/a/2qL56HDgCSPBQPXnbk7dzZdDH.svg)](https://asciinema.org/a/2qL56HDgCSPBQPXnbk7dzZdDH)

