### PR TITLE
docs: adding Godot 3.6.2 and other README.md improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ shipthis login
 
 Run the [wizard command](https://shipth.is/docs/reference/game/wizard?ref=github_readme) to configure your game on ShipThis; it will set up everything needed to automatically build and publish your Godot game.
 
- The wizard command takes a platform parameter: either **android** or **ios**. Run the command from within a Godot game directory (with a **project.godot** file):
+The wizard command takes a platform parameter: either **android** or **ios**. Run the command from within a Godot game directory (with a **project.godot** file):
 
 #### Set up an Android game
 


### PR DESCRIPTION
## Description

This is to resolve #104 

## What's changed

- Added 3.6.2 to version table
- Removed 3.7 custom build from version table
- Consistency tweaks (capitalisation on 'developer account' and setup vs set-up)
- Updated top bullets to separate building and publishing
