### PR TITLE
fix: require `--platform` when using `--useDemoCredentials` on `shipthis game ship`

### DIFF
--- a/docs/game/ship.md
+++ b/docs/game/ship.md
@@ -35,17 +35,18 @@ When using ShipThis in a CI environment, it is most useful to use the `--follow`
 
 ```help
 USAGE
-  $ shipthis game ship [-g <value>] [--download <value> --platform android|ios] [--downloadAPK <value> ] [--follow ] [--skipPublish] [--verbose] [--useDemoCredentials]
+  $ shipthis game ship [-g <value>] [--download <value> --platform android|ios] [--downloadAPK <value> ] [--follow ]
+    [--skipPublish] [--verbose] [--useDemoCredentials ]
 
 FLAGS
   -g, --gameId=<value>       The ID of the game
       --download=<value>     Download the build artifact to the specified file
       --downloadAPK=<value>  Download the APK artifact (if available) to the specified file
-      --follow               Follow the job logs in real-time. Requires --platform to be specified.
+      --follow               Follow the job logs in real-time (requires --platform)
       --platform=<option>    The platform to ship the game to. This can be "android" or "ios"
                              <options: android|ios>
       --skipPublish          Skip the publish step
-      --useDemoCredentials   Use demo credentials for this build (implies --skipPublish)
+      --useDemoCredentials   Use demo credentials for this build (requires --platform, implies --skipPublish)
       --verbose              Enable verbose logging
 
 DESCRIPTION
@@ -64,4 +65,5 @@ EXAMPLES
 
   $ shipthis game ship --platform ios --follow --verbose
 
+  $ shipthis game ship --platform ios --useDemoCredentials --download game.ipa
 ```

--- a/src/commands/game/ship.tsx
+++ b/src/commands/game/ship.tsx
@@ -19,6 +19,7 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
     '<%= config.bin %> <%= command.id %> --platform android --download game.aab',
     '<%= config.bin %> <%= command.id %> --platform android --follow --downloadAPK game.apk',
     '<%= config.bin %> <%= command.id %> --platform ios --follow --verbose',
+    '<%= config.bin %> <%= command.id %> --platform ios --useDemoCredentials --download game.ipa'
   ]
 
   static override flags = {
@@ -35,7 +36,7 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
     }),
     follow: Flags.boolean({
       dependsOn: ['platform'],
-      description: 'Follow the job logs in real-time. Requires --platform to be specified.',
+      description: 'Follow the job logs in real-time (requires --platform)',
       required: false,
     }),
     platform: Flags.string({
@@ -54,7 +55,8 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
       required: false,
     }),
     useDemoCredentials: Flags.boolean({
-      description: 'Use demo credentials for this build (implies --skipPublish)',
+      dependsOn: ['platform' ],
+      description: 'Use demo credentials for this build (requires --platform, implies --skipPublish)',
       required: false,
     }),
   }


### PR DESCRIPTION
## Background

This is to resolve #107.

The backend needs a platform to be specified when we do a build with demo credentials

## What's changed

- Updated the flag dependencies
- Updated the flag description
- Updated the help output in the doc page for the ship command
