### PR TITLE
fix: display correct success message when using `--useDemoCredentials` flag

### DIFF
--- a/assets/markdown/ship-success.md.ejs
+++ b/assets/markdown/ship-success.md.ejs
@@ -2,6 +2,10 @@
 
 **Your game has been successfully built<% if (wasPublished) { %> and published<% } %>.**
 
+<% if (usedDemoCredentials) { %>
+> **Note: Demo credentials were used for this build, so the game was not published.**
+<% } %>
+
 ## Next Steps
 
 - See all builds in the **Dashboard** [<%= gameBuildsUrl %>](<%= gameBuildsUrl %>)

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -134,7 +134,8 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
               filename="ship-success.md.ejs"
               templateVars={{
                 gameBuildsUrl: `${WEB_URL}games/${getShortUUID(gameId)}/builds`,
-                wasPublished: !flags?.skipPublish,
+                wasPublished: !(flags?.skipPublish || flags?.useDemoCredentials),
+                usedDemoCredentials: !!flags?.useDemoCredentials,
               }}
             />
           )}


### PR DESCRIPTION
## Description

This is to resolve #109 which relates to the success message not being in line with what the tool has done

## What's changed

- Passing correct value for `wasPublished` to the template
- Adding message shown if `useDemoCredentials` is set

## Screenshot

<img width="1373" height="380" alt="image" src="https://github.com/user-attachments/assets/81a5cdb4-9fe4-4440-8e20-848c55fe87cc" />
