### PR TITLE
feature: ignore any previously generated `apk` and `aab` files

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -19,6 +19,8 @@ export const DEFAULT_IGNORED_FILES_GLOBS = [
   '.mono/**',
   'data_*/**',
   'mono_crash.*.json',
+  '*.apk',
+  '*.aab',
 ]
 
 const PRIMARY_DOMAIN = 'shipth.is'


### PR DESCRIPTION
Small change - just adding to the default exclusions to include aab and apk