### PR TITLE
fix: ignore built files and temp files from previous android builds

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -21,6 +21,33 @@ export const DEFAULT_IGNORED_FILES_GLOBS = [
   'mono_crash.*.json',
   '*.apk',
   '*.aab',
+  // OS cruft
+  '.DS_Store',
+  'Thumbs.db',
+  // IDE project files
+  '*.iml',
+  '.idea/',
+  '.vscode/',
+  // Gradle + build outputs
+  '.gradle/',
+  '**/build/',
+  // Android local config
+  'local.properties',
+  // Signing (keep secrets out of git)
+  '*.jks',
+  '*.keystore',
+  'keystore.properties',
+  // NDK
+  '.cxx/',
+  '.externalNativeBuild/',
+  // Misc temp
+  '*.log',
+  '*.tmp',
+  '*.temp',
+  '*.swp',
+  '*.swo',
+  '*~',
+  '.env',
 ]
 
 const PRIMARY_DOMAIN = 'shipth.is'


### PR DESCRIPTION
This is to resolve #95

## What's changed

- Took the gitignore used in a number of android kotlin & java projects
- Converted this to the globs