### PR TITLE
fix: `shipthis game ios app addTester` was not adding the current user as a tester

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.49",
       "license": "MIT",
       "dependencies": {
-        "@expo/apple-utils": "^2.1.12",
+        "@expo/apple-utils": "^2.1.21",
         "@expo/json-file": "^8.3.3",
         "@inkjs/ui": "^2.0.0",
         "@oclif/core": "^4.10.2",
@@ -1749,9 +1749,9 @@
       }
     },
     "node_modules/@expo/apple-utils": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/@expo/apple-utils/-/apple-utils-2.1.14.tgz",
-      "integrity": "sha512-6k9KAyk/itPvNgkAI3LactHJyD/S8Jq2V3iEZRm2LMRDx/Gpu4KvqX1dQBon2G7qFM/AEkLO1dToF/dirB7K2Q==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/@expo/apple-utils/-/apple-utils-2.1.21.tgz",
+      "integrity": "sha512-8GINSFSkY4jFOOjd5sniaPVO/27h9atF2rMSyGEKqAOe3SInDYXBY79EapdJtos3shnhGwVZRzZfeFEIEDwDFw==",
       "license": "MIT",
       "bin": {
         "apple-utils": "bin.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/shipth-is/cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "^2.1.12",
+    "@expo/apple-utils": "^2.1.21",
     "@expo/json-file": "^8.3.3",
     "@inkjs/ui": "^2.0.0",
     "@oclif/core": "^4.10.2",

--- a/src/commands/game/ios/app/addTester.tsx
+++ b/src/commands/game/ios/app/addTester.tsx
@@ -31,7 +31,8 @@ export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosA
     }),
     testGroupName: Flags.string({
       char: 't',
-      description: 'The name of the test group to add the tester to (defaults to "ShipThis Test Group (Internal)")',
+      default: TEST_GROUP_NAME,
+      description: 'The name of the internal test group to add the tester to',
     }),
   }
 
@@ -79,7 +80,7 @@ export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosA
 
       const groups = await BetaGroup.getAsync(ctx, {})
 
-      const testGroupName = flags.testGroupName || TEST_GROUP_NAME
+      const testGroupName = flags.testGroupName
 
       let shipThisGroup = groups.find(
         (group) => group.attributes.name === testGroupName && group.attributes.isInternalGroup,
@@ -93,7 +94,7 @@ export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosA
           name: testGroupName,
         })
 
-        console.log(`Created test group ${testGroupName}`)
+        if (!flags.quiet) this.log(`Created test group ${testGroupName}`)
       }
 
       await shipThisGroup.createBulkBetaTesterAssignmentsAsync([
@@ -104,7 +105,7 @@ export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosA
         },
       ])
 
-      console.log(`Added test user ${email} to group ${testGroupName}`)
+      if (!flags.quiet) this.log(`Added test user ${email} to group ${testGroupName}`)
     }
 
     const handleComplete = async () => {}

--- a/src/commands/game/ios/app/addTester.tsx
+++ b/src/commands/game/ios/app/addTester.tsx
@@ -32,7 +32,7 @@ export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosA
     testGroupName: Flags.string({
       char: 't',
       default: TEST_GROUP_NAME,
-      description: `The name of the internal test group to add the tester to (default: ${TEST_GROUP_NAME})`,
+      description: `The name of the internal test group`,
     }),
   }
 

--- a/src/commands/game/ios/app/addTester.tsx
+++ b/src/commands/game/ios/app/addTester.tsx
@@ -32,7 +32,7 @@ export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosA
     testGroupName: Flags.string({
       char: 't',
       default: TEST_GROUP_NAME,
-      description: 'The name of the internal test group to add the tester to',
+      description: `The name of the internal test group to add the tester to (default: ${TEST_GROUP_NAME})`,
     }),
   }
 

--- a/src/commands/game/ios/app/addTester.tsx
+++ b/src/commands/game/ios/app/addTester.tsx
@@ -6,14 +6,17 @@ import {BaseGameCommand} from '@cli/baseCommands/index.js'
 import {Command, RunWithSpinner} from '@cli/components/index.js'
 import {getInput, queryAppleApp} from '@cli/utils/index.js'
 
-const TEST_GROUP_NAME = 'ShipThis Test Group'
+const TEST_GROUP_NAME = 'ShipThis Test Group (Internal)'
 
 export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosAppAddTester> {
   static override args = {}
 
   static override description = 'Adds a test user to the game in App Store Connect.'
 
-  static override examples = ['<%= config.bin %> <%= command.id %>']
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --testGroupName "Testers"',
+  ]
 
   static override flags = {
     email: Flags.string({char: 'e', description: 'The email address of the tester'}),
@@ -25,6 +28,10 @@ export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosA
       char: 's',
       default: false,
       description: 'Add yourself as a tester (uses your Apple ID email and name)',
+    }),
+    testGroupName: Flags.string({
+      char: 't',
+      description: 'The name of the test group to add the tester to (defaults to "ShipThis Test Group (Internal)")',
     }),
   }
 
@@ -72,16 +79,21 @@ export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosA
 
       const groups = await BetaGroup.getAsync(ctx, {})
 
+      const testGroupName = flags.testGroupName || TEST_GROUP_NAME
+
       let shipThisGroup = groups.find(
-        (group) => group.attributes.name === TEST_GROUP_NAME && group.attributes.isInternalGroup,
+        (group) => group.attributes.name === testGroupName && group.attributes.isInternalGroup,
       )
+
       if (!shipThisGroup) {
         shipThisGroup = await BetaGroup.createAsync(ctx, {
           hasAccessToAllBuilds: true,
           id: app.id,
           isInternalGroup: true,
-          name: TEST_GROUP_NAME,
+          name: testGroupName,
         })
+
+        console.log(`Created test group ${testGroupName}`)
       }
 
       await shipThisGroup.createBulkBetaTesterAssignmentsAsync([
@@ -91,6 +103,8 @@ export default class GameIosAppAddTester extends BaseGameCommand<typeof GameIosA
           lastName,
         },
       ])
+
+      console.log(`Added test user ${email} to group ${testGroupName}`)
     }
 
     const handleComplete = async () => {}


### PR DESCRIPTION
This is to resolve #189

## What's changed:

- Updated the @expo/apple-utils library
- Changed the default group name
- Added the option to pass in a group name
- Added extra output