### PR TITLE
chore: Override uuid version to override transitive dependency from xcode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14165,15 +14165,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/xcode/node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "cli-spinners": "2.9.2",
-    "@alcalzone/ansi-tokenize": "^0.2.2"
+    "@alcalzone/ansi-tokenize": "^0.2.2",
+    "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
This is to resolve https://github.com/shipth-is/cli/security/dependabot/61

Forcing the uuid version