### PR TITLE
fix: EventEmiiter warning when running `shipthis game wizard ios`

### DIFF
--- a/src/baseCommands/baseCommand.ts
+++ b/src/baseCommands/baseCommand.ts
@@ -155,10 +155,6 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
   }
 
   public async init(): Promise<void> {
-    // TODO: is this the best place?
-    process.on('SIGINT', () => process.exit(0))
-    process.on('SIGTERM', () => process.exit(0))
-
     await super.init()
     const {args, flags} = await this.parse({
       args: this.ctor.args,


### PR DESCRIPTION
This is to resolve #191 

## What's changed

- Removed the process.on listeners in baseCommand
- These were added when we were initially working on following the job logs

## Testing

I have tested the following:
- `shipthis game wizard ios`
- `shipthis game ship`
- `shipthis game ship --platform ios --follow`
- `shipthis game wizard android`

These listeners were added to solve a problem, but we are not certain which problem. All of these related commands are working correctly. I have been able to run them successfully and run them and press Ctrl+C and they exit correctly.


