### PR TITLE
chore: Upgrade axios to resolve security issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@tanstack/react-query": "^5.56.2",
         "@types/marked-terminal": "^6.1.1",
         "@types/uuid": "^10.0.0",
-        "axios": "^1.7.7",
+        "axios": "^1.16.0",
         "chalk": "^5.4.1",
         "fast-glob": "^3.3.2",
         "fs-extra": "^11.2.0",
@@ -5118,12 +5118,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-query": "^5.56.2",
     "@types/marked-terminal": "^6.1.1",
     "@types/uuid": "^10.0.0",
-    "axios": "^1.7.7",
+    "axios": "^1.16.0",
     "chalk": "^5.4.1",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",


### PR DESCRIPTION
This is to resolve:

https://github.com/shipth-is/cli/security/dependabot/64
https://github.com/shipth-is/cli/security/dependabot/62
https://github.com/shipth-is/cli/security/dependabot/66
https://github.com/shipth-is/cli/security/dependabot/68

and other less serious issues.

## What's changed

- upgraded axios and changed it in package.json too (before it just had ^1.7.7 which without the package-lock.json could point to an insecure ver)
- The new axios ver is 1 week old - this is not a bump to the very latest release (has been through a cool down period)
