### PR TITLE
feature: command to get the full logs for a job

### DIFF
--- a/docs/game/job.md
+++ b/docs/game/job.md
@@ -48,6 +48,37 @@ EXAMPLES
   $ shipthis game job list --gameId 0c179fc4
 ```
 
+### `game job logs`
+
+#### Description
+
+Downloads the full plain-text logs for a job and writes them to stdout.
+
+#### Help Output
+
+```help
+USAGE
+  $ shipthis game job logs JOB_ID [-g <value>]
+
+ARGUMENTS
+  JOB_ID  The id of the job to get the logs for
+
+FLAGS
+  -g, --gameId=<value>  The ID of the game
+
+DESCRIPTION
+  Downloads the full plain-text logs for a job and writes them to stdout.
+
+EXAMPLES
+  $ shipthis game job logs 4d32239e
+
+  $ shipthis game job logs 4d32239e > job.log
+
+  $ shipthis game job logs 4d32239e | grep -i error
+
+  $ shipthis game job logs --gameId 0c179fc4 4d32239e | less
+```
+
 ### `game job status`
 
 #### Description

--- a/docs/game/job/logs.md
+++ b/docs/game/job/logs.md
@@ -1,0 +1,30 @@
+# Command: `game job logs`
+
+## Description
+
+Downloads the full plain-text logs for a job and writes them to stdout.
+
+## Help Output
+
+```help
+USAGE
+  $ shipthis game job logs JOB_ID [-g <value>]
+
+ARGUMENTS
+  JOB_ID  The id of the job to get the logs for
+
+FLAGS
+  -g, --gameId=<value>  The ID of the game
+
+DESCRIPTION
+  Downloads the full plain-text logs for a job and writes them to stdout.
+
+EXAMPLES
+  $ shipthis game job logs 4d32239e
+
+  $ shipthis game job logs 4d32239e > job.log
+
+  $ shipthis game job logs 4d32239e | grep -i error
+
+  $ shipthis game job logs --gameId 0c179fc4 4d32239e | less
+```

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "./dist/commands/game/ios/profile/show.js",
     "./dist/commands/game/create.js",
     "./dist/commands/game/job/list.js",
+    "./dist/commands/game/job/logs.js",
     "./dist/commands/game/job/status.js",
     "./dist/commands/game/status.js",
     "./dist/commands/game/details.js",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -146,6 +146,18 @@ export async function getJob(jobId: string, projectId: string): Promise<Job> {
   return castJobDates(data)
 }
 
+// Streams the full plain-text log file for a job from /logs/download
+export async function getJobLogsDownloadStream(jobId: string, projectId: string): Promise<NodeJS.ReadableStream> {
+  const headers = getAuthedHeaders()
+  const response = await axios({
+    headers,
+    method: 'GET',
+    responseType: 'stream',
+    url: `${API_URL}/projects/${projectId}/jobs/${jobId}/logs/download`,
+  })
+  return response.data
+}
+
 // Returns a url with an OTP - when visited it authenticates the user
 export async function getSingleUseUrl(destination: string) {
   // Call the API to generate an OTP

--- a/src/commands/game/job/logs.ts
+++ b/src/commands/game/job/logs.ts
@@ -1,0 +1,56 @@
+import {Args} from '@oclif/core'
+
+import {getJob, getJobLogsDownloadStream} from '@cli/api/index.js'
+import {BaseGameCommand} from '@cli/baseCommands/index.js'
+import {Job} from '@cli/types'
+
+export default class GameJobLogs extends BaseGameCommand<typeof GameJobLogs> {
+  static override args = {
+    job_id: Args.string({description: 'The id of the job to get the logs for', required: true}),
+  }
+
+  static override description = 'Downloads the full plain-text logs for a job and writes them to stdout.'
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> 4d32239e',
+    '<%= config.bin %> <%= command.id %> 4d32239e > job.log',
+    '<%= config.bin %> <%= command.id %> 4d32239e | grep -i error',
+    '<%= config.bin %> <%= command.id %> --gameId 0c179fc4 4d32239e | less',
+  ]
+
+  static override flags = {
+    ...super.flags,
+  }
+
+  protected async getJob(): Promise<Job> {
+    try {
+      const game = await this.getGame()
+      const job = await getJob(this.args.job_id, game.id)
+      return job
+    } catch (error: any) {
+      if (error?.response?.status === 404) {
+        this.error('Job not found - please check you have access', {exit: 1})
+      }
+
+      throw error
+    }
+  }
+
+  public async run(): Promise<void> {
+    const job = await this.getJob()
+
+    // Exit cleanly if stdout closes mid-stream (e.g. piped to `head`).
+    process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EPIPE') process.exit(0)
+    })
+
+    const stream = await getJobLogsDownloadStream(job.id, job.project.id)
+
+    for await (const chunk of stream as AsyncIterable<Buffer>) {
+      // write() returns false when stdout's buffer is full; wait for 'drain' before resuming.
+      if (!process.stdout.write(chunk)) {
+        await new Promise<void>((resolve) => process.stdout.once('drain', resolve))
+      }
+    }
+  }
+}

--- a/src/commands/game/job/logs.ts
+++ b/src/commands/game/job/logs.ts
@@ -40,17 +40,23 @@ export default class GameJobLogs extends BaseGameCommand<typeof GameJobLogs> {
     const job = await this.getJob()
 
     // Exit cleanly if stdout closes mid-stream (e.g. piped to `head`).
-    process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+    const handleStdoutError = (err: NodeJS.ErrnoException) => {
       if (err.code === 'EPIPE') process.exit(0)
-    })
+    }
 
-    const stream = await getJobLogsDownloadStream(job.id, job.project.id)
+    process.stdout.on('error', handleStdoutError)
 
-    for await (const chunk of stream as AsyncIterable<Buffer>) {
-      // write() returns false when stdout's buffer is full; wait for 'drain' before resuming.
-      if (!process.stdout.write(chunk)) {
-        await new Promise<void>((resolve) => process.stdout.once('drain', resolve))
+    try {
+      const stream = await getJobLogsDownloadStream(job.id, job.project.id)
+
+      for await (const chunk of stream as AsyncIterable<Buffer>) {
+        // write() returns false when stdout's buffer is full; wait for 'drain' before resuming.
+        if (!process.stdout.write(chunk)) {
+          await new Promise<void>((resolve) => process.stdout.once('drain', resolve))
+        }
       }
+    } finally {
+      process.stdout.removeListener('error', handleStdoutError)
     }
   }
 }


### PR DESCRIPTION
This is to resolve #206 

## What's changed

- Added an API function to get the download stream from the backend
- Added command `shipthis game job logs` to get the full logs for a given job
  - Sends to stdout
  - Handles backpressure
- Added help doc

```bash
$ shipthis game job logs --help
Downloads the full plain-text logs for a job and writes them to stdout.

USAGE
  $ shipthis game job logs JOB_ID [-g <value>]

ARGUMENTS
  JOB_ID  The id of the job to get the logs for

FLAGS
  -g, --gameId=<value>  The ID of the game

DESCRIPTION
  Downloads the full plain-text logs for a job and writes them to stdout.

EXAMPLES
  $ shipthis game job logs 4d32239e

  $ shipthis game job logs 4d32239e > job.log

  $ shipthis game job logs 4d32239e | grep -i error

  $ shipthis game job logs --gameId 0c179fc4 4d32239e | less
```

