### PR TITLE
feature: showing the job logs in the Android wizard

### DIFF
--- a/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
+++ b/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
@@ -68,17 +68,20 @@ export const InitialAndroidBuild = ({gameId, onComplete, onError, ...boxProps}: 
         </Box>
         {androidJob === null && <Text>{shipLog}</Text>}
         {androidJob && (
-          <JobProgress
-            job={androidJob}
-            onComplete={onComplete}
-            onFailure={(j: Job) => {
-              setFailedJob(j)
-              // Wait before triggering the error to allow the job log to be displayed
-              setTimeout(() => {
-                onError(new Error(`Job ${j.id} failed`))
-              }, 1000)
-            }}
-          />
+          <>
+            <JobProgress
+              job={androidJob}
+              onComplete={onComplete}
+              onFailure={(j: Job) => {
+                setFailedJob(j)
+                // Wait before triggering the error to allow the job log to be displayed
+                setTimeout(() => {
+                  onError(new Error(`Job ${j.id} failed`))
+                }, 1000)
+              }}
+            />
+            <JobLogTail isWatching={true} jobId={androidJob.id} length={10} projectId={gameId} />
+          </>
         )}
 
         {failedJob && (

--- a/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
+++ b/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
@@ -66,7 +66,7 @@ export const InitialAndroidBuild = ({gameId, onComplete, onError, ...boxProps}: 
           <Text>Create an initial build...</Text>
           {(isLoadingBuilds || isLoadingJobs || shipMutation.isPending) && <Spinner type="dots" />}
         </Box>
-        {androidJob === null && <Text>{shipLog}</Text>}
+        {androidJob == null && shipLog && <Text>{shipLog}</Text>}
         {androidJob && (
           <>
             <JobProgress


### PR DESCRIPTION
This is to resolve #199 

## What's changed
- Showing JobLogTail below the progress on the wizard

## Screenshots

### Large terminal

<img width="1920" height="1164" alt="image" src="https://github.com/user-attachments/assets/d0011448-75ef-4e08-9448-2c2fd53de550" />

### On a smaller terminal - 80x24
<img width="756" height="500" alt="image" src="https://github.com/user-attachments/assets/3928cc44-ea1b-4236-9514-4e8fce721c06" />
