### PR TITLE
fix:  missing awaits cause incorrect error messages

### DIFF
--- a/src/baseCommands/baseAuthenticatedCommand.ts
+++ b/src/baseCommands/baseAuthenticatedCommand.ts
@@ -12,7 +12,8 @@ export abstract class BaseAuthenticatedCommand<T extends typeof Command> extends
 
   public async init(): Promise<void> {
     await super.init()
-    if (!this.isAuthenticated()) {
+    const isAuthenticated = await this.isAuthenticated()
+    if (!isAuthenticated) {
       this.error('No auth config found. Please run `shipthis login` to authenticate.', {exit: 1})
     }
 

--- a/src/commands/game/android/apiKey/create.tsx
+++ b/src/commands/game/android/apiKey/create.tsx
@@ -26,7 +26,7 @@ export default class GameAndroidApiKeyCreate extends BaseGameAndroidCommand<type
 
     const {force, waitForAuth} = this.flags
 
-    this.checkGoogleAuth(waitForAuth)
+    await this.checkGoogleAuth(waitForAuth)
 
     const projectCredentials = await getProjectCredentials(game.id)
     const hasApiKey = projectCredentials.some(

--- a/src/commands/game/android/apiKey/invite.tsx
+++ b/src/commands/game/android/apiKey/invite.tsx
@@ -30,7 +30,7 @@ export default class GameAndroidApiKeyInvite extends BaseGameAndroidCommand<type
     const game = await this.getGame()
     const {prompt, waitForAuth, waitForGoogleApp} = this.flags
 
-    this.checkGoogleAuth(waitForAuth)
+    await this.checkGoogleAuth(waitForAuth)
 
     const getAccountId = async () => {
       if (!prompt) return this.args.accountId


### PR DESCRIPTION
Resolves #220 

## What's changed

- these functions were async and needed awaits
- `getSelf` still has a check there so this is in no-way an auth bypass (also this is just the client)
