### PR TITLE
fix: waitForAuth now waits the documented 10 mins

### DIFF
--- a/docs/game/android/apiKey.md
+++ b/docs/game/android/apiKey.md
@@ -16,7 +16,7 @@ Connects ShipThis with Google for managing Service Account API Keys for an Andro
 
 ```help
 USAGE
-  $ shipthis game android apiKey connect [-g <value>] [-f] [-d]
+  $ shipthis game android apiKey connect [-g <value>] [-d] [-f]
 
 FLAGS
   -d, --disconnect
@@ -44,7 +44,7 @@ Creates a new Android Service Account API Key for a game
 
 ```help
 USAGE
-  $ shipthis game android apiKey create [-g <value>] [-w] [-f]
+  $ shipthis game android apiKey create [-g <value>] [-f] [-w]
 
 FLAGS
   -f, --force
@@ -96,7 +96,7 @@ Saves the current Android Service Account API Key to a ZIP file
 
 ```help
 USAGE
-  $ shipthis game android apiKey export FILE [-g <value>] [-f]
+  $ shipthis game android apiKey export FILE [-f] [-g <value>]
 
 ARGUMENTS
   FILE  Name of the ZIP file to create
@@ -122,7 +122,7 @@ Imports an Android Service Account API Key to your ShipThis account for the spec
 
 ```help
 USAGE
-  $ shipthis game android apiKey import FILE [-g <value>] [-f]
+  $ shipthis game android apiKey import FILE [-f] [-g <value>]
 
 ARGUMENTS
   FILE  Name of the ZIP file to import (must be in the same format as the export)
@@ -148,15 +148,15 @@ Invites the Service Account to your Google Play Account.
 
 ```help
 USAGE
-  $ shipthis game android apiKey invite [ACCOUNTID] [-g <value>] [-p] [-p] [-w]
+  $ shipthis game android apiKey invite [ACCOUNTID] [-g <value>] [-p] [-w] [-a]
 
 ARGUMENTS
-  ACCOUNTID  The Google Play Account ID
+  [ACCOUNTID]  The Google Play Account ID
 
 FLAGS
+  -a, --waitForGoogleApp  Waits for the Google Play app to be created.
   -g, --gameId=<value>    The ID of the game
   -p, --prompt            Prompt for the Google Play Account ID
-  -p, --waitForGoogleApp  Waits for the Google Play app to be created (10 mins).
   -w, --waitForAuth       Wait for Google Authentication (10 mins).
 
 DESCRIPTION
@@ -164,6 +164,35 @@ DESCRIPTION
 
 EXAMPLES
   $ shipthis game android apiKey invite
+```
+
+### `game android apiKey policy`
+
+#### Description
+
+Gets and sets the iam.disableServiceAccountKeyCreation policy for your Google Organization
+
+#### Help Output
+
+```help
+USAGE
+  $ shipthis game android apiKey policy [-g <value>] [-e | -r] [-w]
+
+FLAGS
+  -e, --enforce         Enforces the policy
+  -g, --gameId=<value>  The ID of the game
+  -r, --revoke          Revokes the policy
+  -w, --waitForAuth     Wait for Google Authentication (10 mins).
+
+DESCRIPTION
+  Gets and sets the iam.disableServiceAccountKeyCreation policy for your Google Organization
+
+EXAMPLES
+  $ shipthis game android apiKey policy
+
+  $ shipthis game android apiKey policy --enforce
+
+  $ shipthis game android apiKey policy --revoke
 ```
 
 ### `game android apiKey show`

--- a/docs/game/android/apiKey/invite.md
+++ b/docs/game/android/apiKey/invite.md
@@ -8,15 +8,15 @@ Invites the Service Account to your Google Play Account.
 
 ```help
 USAGE
-  $ shipthis game android apiKey invite [ACCOUNTID] [-g <value>] [-p] [-p] [-w]
+  $ shipthis game android apiKey invite [ACCOUNTID] [-g <value>] [-p] [-w] [-a]
 
 ARGUMENTS
-  ACCOUNTID  The Google Play Account ID
+  [ACCOUNTID]  The Google Play Account ID
 
 FLAGS
+  -a, --waitForGoogleApp  Waits for the Google Play app to be created.
   -g, --gameId=<value>    The ID of the game
   -p, --prompt            Prompt for the Google Play Account ID
-  -p, --waitForGoogleApp  Waits for the Google Play app to be created (10 mins).
   -w, --waitForAuth       Wait for Google Authentication (10 mins).
 
 DESCRIPTION

--- a/src/baseCommands/baseGameAndroidCommand.ts
+++ b/src/baseCommands/baseGameAndroidCommand.ts
@@ -16,7 +16,7 @@ export abstract class BaseGameAndroidCommand<T extends typeof Command> extends B
     this.log('Waiting for Google authentication...')
     const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-    for (let i = 0; i < 600; i++) {
+    for (let i = 0; i < 60; i++) {
       process.stdout.write('.')
       await sleep(1000 * 10)
       status = await getGoogleStatus()

--- a/src/commands/game/android/apiKey/invite.tsx
+++ b/src/commands/game/android/apiKey/invite.tsx
@@ -23,7 +23,7 @@ export default class GameAndroidApiKeyInvite extends BaseGameAndroidCommand<type
     ...BaseGameAndroidCommand.flags,
     prompt: Flags.boolean({char: 'p', description: 'Prompt for the Google Play Account ID'}),
     waitForAuth: Flags.boolean({char: 'w', description: 'Wait for Google Authentication (10 mins).'}),
-    waitForGoogleApp: Flags.boolean({char: 'p', description: 'Waits for the Google Play app to be created (10 mins).'}),
+    waitForGoogleApp: Flags.boolean({char: 'a', description: 'Waits for the Google Play app to be created.'}),
   }
 
   public async run(): Promise<void> {


### PR DESCRIPTION
Resolves #221

  ## What's changed

  - `checkGoogleAuth` looped 600 times with a 10 second sleep
  - reduced to 60 iterations to match the flag descriptions (10 mins)

  Also in `invite` - not in the issue, but the same "(10 mins)" claim:

  - `--waitForGoogleApp` polls forever so dropped the false "(10 mins)" from its description
  - `--waitForGoogleApp` had `char: 'p'`, clash with `--prompt`  - moved it to `-a`.
  - changing the short flag is not a breaking change as it did not work via `-p`
