### PR TITLE
fix: docs drift, plus two breaking flag fixes

### DIFF
--- a/docs/apple/login.md
+++ b/docs/apple/login.md
@@ -24,18 +24,24 @@ your behalf. To do this, ShipThis generates temporary session cookies which it r
 
 ```help
 USAGE
-  $ shipthis apple login [-q] [-f] [-e <value>]
+  $ shipthis apple login [-e <value>] [-f] [-q] [-l]
 
 FLAGS
   -e, --appleEmail=<value>  Your Apple Developer email address
   -f, --force
+  -l, --logout              Forget the saved Apple session (log out)
   -q, --quiet               Avoid output except for interactions and errors
 
 DESCRIPTION
-  Authenticate with Apple - saves the session to the auth file
+  Authenticate with Apple - saves the session to the auth file.
+
+  Your Apple password is sent only to Apple, never to ShipThis. Only the resulting session cookies are saved locally.
+  Read the source: https://github.com/shipth-is/cli/blob/main/src/commands/apple/login.ts
 
 EXAMPLES
   $ shipthis apple login
 
   $ shipthis apple login --force --appleEmail me@email.nowhere
+
+  $ shipthis apple login --logout
 ```

--- a/docs/autocomplete.md
+++ b/docs/autocomplete.md
@@ -43,7 +43,7 @@ USAGE
   $ shipthis autocomplete [SHELL] [-r]
 
 ARGUMENTS
-  SHELL  (zsh|bash|powershell) Shell type
+  [SHELL]  (zsh|bash|powershell) Shell type
 
 FLAGS
   -r, --refresh-cache  Refresh cache (ignores displaying instructions)

--- a/docs/game/create.md
+++ b/docs/game/create.md
@@ -28,19 +28,23 @@ command.
 
 ```help
 USAGE
-  $ shipthis game create [-q] [-f] [-n <value>] [-b <value>] [-s <value>] [-e <value>] [-v <value>] [-i <value>]
-    [-a <value>]
+  $ shipthis game create [-f] [-q] [-a <value>] [-b <value>] [-e <value>] [-v <value>] [-g <value>] [-c <value>]
+    [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d <value>]
 
 FLAGS
-  -a, --androidPackageName=<value>  Set the Android package name
-  -b, --buildNumber=<value>         Set the build number
-  -e, --gameEngine=<value>          Set the game engine
+  -a, --androidPackageName=<value>   Set the Android package name
+  -b, --buildNumber=<value>          Set the build number
+  -c, --gcpServiceAccountId=<value>  Set the GCP service account ID
+  -d, --useDemoCredentials=<value>   Use demo credentials for this project
+  -e, --gameEngine=<value>           Set the game engine
   -f, --force
-  -i, --iosBundleId=<value>         Set the iOS bundle ID
-  -n, --name=<value>                The name of the game
-  -q, --quiet                       Avoid output except for interactions and errors
-  -s, --semanticVersion=<value>     Set the semantic version
-  -v, --gameEngineVersion=<value>   Set the game engine version
+  -g, --gcpProjectId=<value>         Set the GCP project ID
+  -i, --iosBundleId=<value>          Set the iOS bundle ID
+  -l, --liquidGlassIconPath=<value>  Set the Liquid Glass icon path
+  -n, --name=<value>                 The name of the game
+  -q, --quiet                        Avoid output except for interactions and errors
+  -s, --semanticVersion=<value>      Set the semantic version
+  -v, --gameEngineVersion=<value>    Set the game engine version
 
 DESCRIPTION
   Create a new game in ShipThis.

--- a/docs/game/create.md
+++ b/docs/game/create.md
@@ -29,13 +29,14 @@ command.
 ```help
 USAGE
   $ shipthis game create [-f] [-q] [-a <value>] [-b <value>] [-e <value>] [-v <value>] [-g <value>] [-c <value>]
-    [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d <value>]
+    [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d true|false]
 
 FLAGS
   -a, --androidPackageName=<value>   Set the Android package name
   -b, --buildNumber=<value>          Set the build number
   -c, --gcpServiceAccountId=<value>  Set the GCP service account ID
-  -d, --useDemoCredentials=<value>   Use demo credentials for this project
+  -d, --useDemoCredentials=<option>  Use demo credentials for this project
+                                     <options: true|false>
   -e, --gameEngine=<value>           Set the game engine
   -f, --force
   -g, --gcpProjectId=<value>         Set the GCP project ID

--- a/docs/game/create.md
+++ b/docs/game/create.md
@@ -28,8 +28,8 @@ command.
 
 ```help
 USAGE
-  $ shipthis game create [-f] [-q] [-a <value>] [-b <value>] [-e <value>] [-v <value>] [-g <value>] [-c <value>]
-    [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d true|false]
+  $ shipthis game create [-f] [-q] [-a <value>] [-b <value>] [-e <value>] [-v <value>] [--gcpProjectId <value>]
+    [-c <value>] [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d true|false]
 
 FLAGS
   -a, --androidPackageName=<value>   Set the Android package name
@@ -39,13 +39,13 @@ FLAGS
                                      <options: true|false>
   -e, --gameEngine=<value>           Set the game engine
   -f, --force
-  -g, --gcpProjectId=<value>         Set the GCP project ID
   -i, --iosBundleId=<value>          Set the iOS bundle ID
   -l, --liquidGlassIconPath=<value>  Set the Liquid Glass icon path
   -n, --name=<value>                 The name of the game
   -q, --quiet                        Avoid output except for interactions and errors
   -s, --semanticVersion=<value>      Set the semantic version
   -v, --gameEngineVersion=<value>    Set the game engine version
+      --gcpProjectId=<value>         Set the GCP project ID
 
 DESCRIPTION
   Create a new game in ShipThis.

--- a/docs/game/details.md
+++ b/docs/game/details.md
@@ -29,7 +29,8 @@ After changing these values, you will need to trigger a new build of your game w
 
 ```help
 USAGE
-  $ shipthis game details [-g <value>] [-f] [-a <value>] [-b <value>] [-e <value>] [-v <value>] [-g <value>] [-c <value>] [-i <value>] [-n <value>] [-s <value>] [-d <value>]
+  $ shipthis game details [-g <value>] [-f] [-a <value>] [-b <value>] [-e <value>] [-v <value>] [-g <value>] [-c
+    <value>] [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d <value>]
 
 FLAGS
   -a, --androidPackageName=<value>   Set the Android package name
@@ -41,6 +42,7 @@ FLAGS
   -g, --gameId=<value>               The ID of the game
   -g, --gcpProjectId=<value>         Set the GCP project ID
   -i, --iosBundleId=<value>          Set the iOS bundle ID
+  -l, --liquidGlassIconPath=<value>  Set the Liquid Glass icon path
   -n, --name=<value>                 The name of the game
   -s, --semanticVersion=<value>      Set the semantic version
   -v, --gameEngineVersion=<value>    Set the game engine version

--- a/docs/game/details.md
+++ b/docs/game/details.md
@@ -30,13 +30,14 @@ After changing these values, you will need to trigger a new build of your game w
 ```help
 USAGE
   $ shipthis game details [-g <value>] [-f] [-a <value>] [-b <value>] [-e <value>] [-v <value>] [-g <value>] [-c
-    <value>] [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d <value>]
+    <value>] [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d true|false]
 
 FLAGS
   -a, --androidPackageName=<value>   Set the Android package name
   -b, --buildNumber=<value>          Set the build number
   -c, --gcpServiceAccountId=<value>  Set the GCP service account ID
-  -d, --useDemoCredentials=<value>   Use demo credentials for this project
+  -d, --useDemoCredentials=<option>  Use demo credentials for this project
+                                     <options: true|false>
   -e, --gameEngine=<value>           Set the game engine
   -f, --force                        Force the command to run
   -g, --gameId=<value>               The ID of the game

--- a/docs/game/details.md
+++ b/docs/game/details.md
@@ -29,8 +29,8 @@ After changing these values, you will need to trigger a new build of your game w
 
 ```help
 USAGE
-  $ shipthis game details [-g <value>] [-f] [-a <value>] [-b <value>] [-e <value>] [-v <value>] [-g <value>] [-c
-    <value>] [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d true|false]
+  $ shipthis game details [-g <value>] [-f] [-a <value>] [-b <value>] [-e <value>] [-v <value>] [--gcpProjectId
+    <value>] [-c <value>] [-i <value>] [-l <value>] [-n <value>] [-s <value>] [-d true|false]
 
 FLAGS
   -a, --androidPackageName=<value>   Set the Android package name
@@ -41,12 +41,12 @@ FLAGS
   -e, --gameEngine=<value>           Set the game engine
   -f, --force                        Force the command to run
   -g, --gameId=<value>               The ID of the game
-  -g, --gcpProjectId=<value>         Set the GCP project ID
   -i, --iosBundleId=<value>          Set the iOS bundle ID
   -l, --liquidGlassIconPath=<value>  Set the Liquid Glass icon path
   -n, --name=<value>                 The name of the game
   -s, --semanticVersion=<value>      Set the semantic version
   -v, --gameEngineVersion=<value>    Set the game engine version
+      --gcpProjectId=<value>         Set the GCP project ID
 
 DESCRIPTION
   Shows and sets the details of a game.

--- a/docs/game/ios.md
+++ b/docs/game/ios.md
@@ -21,4 +21,5 @@ these commands. To do that please run the following commands first:
 ## Commands
 
 - [game ios status](/docs/reference/game/ios/status)
+- [game ios wizard](/docs/reference/game/ios/wizard)
 

--- a/docs/game/ios/app.md
+++ b/docs/game/ios/app.md
@@ -22,6 +22,36 @@ these commands. To do that please run the following commands first:
 
 ## Commands
 
+### `game ios app addTester`
+
+#### Description
+
+Adds a test user to the game in App Store Connect.
+
+#### Help Output
+
+```help
+USAGE
+  $ shipthis game ios app addTester [-e <value>] [-f <value>] [-g <value>] [-l <value>] [-q] [-s] [-t <value>]
+
+FLAGS
+  -e, --email=<value>          The email address of the tester
+  -f, --firstName=<value>      The first name of the tester
+  -g, --gameId=<value>         The ID of the game
+  -l, --lastName=<value>       The last name of the tester
+  -q, --quiet                  Avoid output except for interactions and errors
+  -s, --self                   Add yourself as a tester (uses your Apple ID email and name)
+  -t, --testGroupName=<value>  [default: ShipThis Test Group (Internal)] The name of the internal test group
+
+DESCRIPTION
+  Adds a test user to the game in App Store Connect.
+
+EXAMPLES
+  $ shipthis game ios app addTester
+
+  $ shipthis game ios app addTester --testGroupName "Testers"
+```
+
 ### `game ios app create`
 
 #### Description
@@ -42,7 +72,7 @@ to be unique within the Apple ecosystem. ShipThis will suggest values for these.
 
 ```help
 USAGE
-  $ shipthis game ios app create [-q] [-g <value>] [-n <value>] [-b <value>] [-f]
+  $ shipthis game ios app create [-n <value>] [-b <value>] [-f] [-g <value>] [-q]
 
 FLAGS
   -b, --bundleId=<value>  The BundleId in the Apple Developer Portal
@@ -120,7 +150,7 @@ ShipThis will use default values for this file if it does not exist.
 
 ```help
 USAGE
-  $ shipthis game ios app sync [-q] [-g <value>] [-f]
+  $ shipthis game ios app sync [-f] [-g <value>] [-q]
 
 FLAGS
   -f, --force

--- a/docs/game/ios/app/addTester.md
+++ b/docs/game/ios/app/addTester.md
@@ -8,17 +8,22 @@ Adds a test user to the game in App Store Connect.
 
 ```help
 USAGE
-  $ shipthis game ios app addTester [-g <value>] [-e <value>] [-f <value>] [-l <value>]
+  $ shipthis game ios app addTester [-e <value>] [-f <value>] [-g <value>] [-l <value>] [-q] [-s] [-t <value>]
 
 FLAGS
-  -e, --email=<value>      The email address of the tester
-  -f, --firstName=<value>  The first name of the tester
-  -g, --gameId=<value>     The ID of the game
-  -l, --lastName=<value>   The last name of the tester
+  -e, --email=<value>          The email address of the tester
+  -f, --firstName=<value>      The first name of the tester
+  -g, --gameId=<value>         The ID of the game
+  -l, --lastName=<value>       The last name of the tester
+  -q, --quiet                  Avoid output except for interactions and errors
+  -s, --self                   Add yourself as a tester (uses your Apple ID email and name)
+  -t, --testGroupName=<value>  [default: ShipThis Test Group (Internal)] The name of the internal test group
 
 DESCRIPTION
   Adds a test user to the game in App Store Connect.
 
 EXAMPLES
   $ shipthis game ios app addTester
+
+  $ shipthis game ios app addTester --testGroupName "Testers"
 ```

--- a/docs/game/ship.md
+++ b/docs/game/ship.md
@@ -55,13 +55,15 @@ shipthis game ship --platform android --follow --gameEngineVersion 4.5.1 --downl
 
 ```help
 USAGE
-  $ shipthis game ship [-g <value>] [--download <value> --platform android|ios] [--downloadAPK <value> ] [--follow ] [--skipPublish] [--verbose] [--useDemoCredentials ]
-    [--gameEngineVersion <value>]
+  $ shipthis game ship [-g <value>] [--download <value> --platform android|ios] [--downloadAPK <value> ]
+    [--follow ] [--skipPublish] [--verbose] [--useDemoCredentials ] [--gameEngineVersion <value>] [--dryRun]
 
 FLAGS
   -g, --gameId=<value>             The ID of the game
       --download=<value>           Download the build artifact to the specified file
       --downloadAPK=<value>        Download the APK artifact (if available) to the specified file
+      --dryRun                     Dry run - lists the files that would be shipped without executing the build or
+                                   publish steps
       --follow                     Follow the job logs in real-time (requires --platform)
       --gameEngineVersion=<value>  Override the specified game engine version for this build
       --platform=<option>          The platform to ship the game to. This can be "android" or "ios"
@@ -89,4 +91,6 @@ EXAMPLES
   $ shipthis game ship --platform ios --useDemoCredentials --download game.ipa
 
   $ shipthis game ship --platform android --gameEngineVersion 4.5.1 --skipPublish
+
+  $ shipthis game ship --platform android --dryRun
 ```

--- a/docs/game/status.md
+++ b/docs/game/status.md
@@ -12,10 +12,12 @@ Shows the status of a specific game (generally in the currently directory).
 
 ```help
 USAGE
-  $ shipthis game status [-g <value>]
+  $ shipthis game status [-g <value>] [-p android|ios]
 
 FLAGS
-  -g, --gameId=<value>  The ID of the game
+  -g, --gameId=<value>     The ID of the game
+  -p, --platform=<option>  The platform to check status for (ios, android)
+                           <options: android|ios>
 
 DESCRIPTION
   Shows the status of the current game.
@@ -24,4 +26,6 @@ EXAMPLES
   $ shipthis game status
 
   $ shipthis game status --gameId 0c179fc4
+
+  $ shipthis game status --platform ios
 ```

--- a/docs/game/wizard.md
+++ b/docs/game/wizard.md
@@ -23,13 +23,10 @@ To do that please run the following command first:
 
 ```help
 USAGE
-  $ shipthis game wizard PLATFORM [-f <value>]
+  $ shipthis game wizard PLATFORM
 
 ARGUMENTS
-  PLATFORM  The platform to run the wizard for
-
-FLAGS
-  -f, --forceStep=<value>  Force a specific step to run.
+  PLATFORM  (android|ios) The platform to run the wizard for. This can be "android" or "ios"
 
 DESCRIPTION
   Runs all the steps for the specific platform

--- a/src/commands/game/details.tsx
+++ b/src/commands/game/details.tsx
@@ -64,7 +64,7 @@ export default class GameDetails extends BaseGameCommand<typeof GameDetails> {
         ...(iosBundleId && {iosBundleId}),
         ...(liquidGlassIconPath !== undefined && {liquidGlassIconPath}),
         ...(semanticVersion && {semanticVersion}),
-        ...(useDemoCredentials !== undefined && {useDemoCredentials: useDemoCredentials.toLowerCase() === 'true'}),
+        ...(useDemoCredentials !== undefined && {useDemoCredentials: useDemoCredentials === 'true'}),
       },
       name: name || game.name,
     }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,5 +14,9 @@ export const DetailsFlags = {
   liquidGlassIconPath: Flags.string({char: 'l', description: 'Set the Liquid Glass icon path'}),
   name: Flags.string({char: 'n', description: 'The name of the game'}),
   semanticVersion: Flags.string({char: 's', description: 'Set the semantic version'}),
-  useDemoCredentials: Flags.string({char: 'd', description: 'Use demo credentials for this project'}),
+  useDemoCredentials: Flags.string({
+    char: 'd',
+    description: 'Use demo credentials for this project',
+    options: ['true', 'false'],
+  }),
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,7 +8,8 @@ export const DetailsFlags = {
   buildNumber: Flags.integer({char: 'b', description: 'Set the build number'}),
   gameEngine: Flags.string({char: 'e', description: 'Set the game engine'}),
   gameEngineVersion: Flags.string({char: 'v', description: 'Set the game engine version'}),
-  gcpProjectId: Flags.string({char: 'g', description: 'Set the GCP project ID'}),
+  // No short char: -g is reserved CLI-wide for --gameId (see BaseGameCommand)
+  gcpProjectId: Flags.string({description: 'Set the GCP project ID'}),
   gcpServiceAccountId: Flags.string({char: 'c', description: 'Set the GCP service account ID'}),
   iosBundleId: Flags.string({char: 'i', description: 'Set the iOS bundle ID'}),
   liquidGlassIconPath: Flags.string({char: 'l', description: 'Set the Liquid Glass icon path'}),


### PR DESCRIPTION
Tool assisted PR - diffed the auto-gen docs against the actual docs to find where they'd drifted.

  It started as a docs-only pass, but chasing two of the discrepancies turned up real bugs in the CLI itself, so **this PR also changes the flag surface**.
  Two of those changes are breaking — details below.

  ###  Breaking changes

  1. `--useDemoCredentials` now only accepts `true` or `false`

  It was a free-form string flag it is now constrained with `options: ['true', 'false']`, so oclif rejects bad values up front:

  ```
  $ shipthis game create --useDemoCredentials yes
  Error: Expected --useDemoCredentials=yes to be one of: true, false
  ```

  2. `-g` is no longer an alias for `--gcpProjectId`

There was a conflict on `-g` - it should only be used for `gameId`
