### PR TITLE
fix: updated keystore import routine with better error handling and cleanup

### DIFF
--- a/src/utils/query/useImportKeystore.ts
+++ b/src/utils/query/useImportKeystore.ts
@@ -37,51 +37,77 @@ export async function importKeystore({log = () => {}, ...opt}: ImportOptions): P
     throw new Error('You must provide both keystorePassword and keyPassword when importing a jks file')
   }
 
+  // Only ever holds zip files we generated ourselves - never a caller supplied zipFilePath
   const toDelete: string[] = []
 
-  // If we are doing a JKS import then we need to create the zip file
-  if (opt.jksFilePath) {
-    log('Creating zip file from jks file...')
-    const outputZipToFile = (zip: ZipFile, fileName: string) =>
-      new Promise<void>((resolve) => {
-        const outputStream = fs.createWriteStream(fileName)
-        zip.outputStream.pipe(outputStream).on('close', () => resolve())
-        zip.end()
-      })
+  try {
+    // If we are doing a JKS import then we need to create the zip file
+    if (opt.jksFilePath) {
+      log('Creating zip file from jks file...')
+      const outputZipToFile = (zip: ZipFile, fileName: string) =>
+        new Promise<void>((resolve, reject) => {
+          const outputStream = fs.createWriteStream(fileName)
+          let failure: Error | null = null
 
-    // Create a zip file with the jks file
-    const zipFile = new ZipFile()
-    log('Adding keyStore.jks to zip file...')
-    zipFile.addFile(opt.jksFilePath, 'keyStore.jks')
+          // Settle only once the file handle is released, otherwise the stream can
+          // still create the file after cleanup has run
+          const fail = (error: Error) => {
+            if (failure) return
+            failure = error
+            outputStream.destroy()
+          }
 
-    // Add password.txt (keyStorePassword) and keyPassword.txt (keyPassword)
-    log('Adding password.txt and keyPassword.txt to zip file...')
-    zipFile.addBuffer(Buffer.from(`${opt.keystorePassword}`), 'password.txt')
-    zipFile.addBuffer(Buffer.from(`${opt.keyPassword}`), 'keyPassword.txt')
+          // yazl reports entry failures (eg. a missing jks) on the ZipFile itself
+          zip.on('error', fail)
+          zip.outputStream.on('error', fail)
+          outputStream.on('error', fail)
+          outputStream.on('close', () => (failure ? reject(failure) : resolve()))
 
-    const tmpZipFile = `${process.cwd()}/shipthis-keyStore-${uuid()}.zip`
-    log(`Writing zip file: ${tmpZipFile}`)
-    await outputZipToFile(zipFile, tmpZipFile)
-    toDelete.push(tmpZipFile)
-    opt.zipFilePath = tmpZipFile
+          zip.outputStream.pipe(outputStream)
+          zip.end()
+        })
+
+      // Create a zip file with the jks file
+      const zipFile = new ZipFile()
+      log('Adding keyStore.jks to zip file...')
+      zipFile.addFile(opt.jksFilePath, 'keyStore.jks')
+
+      // Add password.txt (keyStorePassword) and keyPassword.txt (keyPassword)
+      log('Adding password.txt and keyPassword.txt to zip file...')
+      zipFile.addBuffer(Buffer.from(`${opt.keystorePassword}`), 'password.txt')
+      zipFile.addBuffer(Buffer.from(`${opt.keyPassword}`), 'keyPassword.txt')
+
+      const tmpZipFile = `${process.cwd()}/shipthis-keyStore-${uuid()}.zip`
+      log(`Writing zip file: ${tmpZipFile}`)
+      // Track before writing so a partially written zip is cleaned up too
+      toDelete.push(tmpZipFile)
+      await outputZipToFile(zipFile, tmpZipFile)
+      opt.zipFilePath = tmpZipFile
+    }
+
+    log('Uploading and importing zip file...')
+    const keyStore = await importCredential({
+      platform: Platform.ANDROID,
+      projectId: opt.gameId,
+      type: CredentialsType.CERTIFICATE,
+      zipPath: `${opt.zipFilePath}`,
+    })
+    log('Imported successfully')
+
+    return keyStore as ProjectCredential
+  } finally {
+    // The generated zip holds the keystore and both passwords in plaintext, so it must
+    // be removed even when the import fails
+    for (const file of toDelete) {
+      if (!fs.existsSync(file)) continue
+      try {
+        log(`Deleting temporary file: ${file}`)
+        fs.unlinkSync(file)
+      } catch (error) {
+        log(`Failed to remove temporary file ${file}: ${String(error)}`)
+      }
+    }
   }
-
-  log('Uploading and importing zip file...')
-  const keyStore = await importCredential({
-    platform: Platform.ANDROID,
-    projectId: opt.gameId,
-    type: CredentialsType.CERTIFICATE,
-    zipPath: `${opt.zipFilePath}`,
-  })
-  log('Imported successfully')
-
-  // Delete the temporary zip files
-  for (const file of toDelete) {
-    log(`Deleting temporary file: ${file}`)
-    fs.unlinkSync(file)
-  }
-
-  return keyStore as ProjectCredential
 }
 
 export const useImportKeystore = () => useMutation({

--- a/test/utils/query/importKeystore.test.ts
+++ b/test/utils/query/importKeystore.test.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {expect} from 'chai'
+
+// Point the API at a closed local port so importCredential rejects without touching
+// the network. This must happen before the modules that read it are loaded.
+process.env.SHIPTHIS_DOMAIN = '127.0.0.1:1'
+const {importKeystore} = await import('@cli/utils/query/useImportKeystore.js')
+
+async function expectRejection(promise: Promise<unknown>): Promise<void> {
+  try {
+    await promise
+  } catch {
+    return
+  }
+
+  expect.fail('Expected importKeystore to reject')
+}
+
+const generatedZips = (dir: string) => fs.readdirSync(dir).filter((f) => f.startsWith('shipthis-keyStore-'))
+
+describe('importKeystore (query/useImportKeystore)', () => {
+  let workDir: string
+  let originalCwd: string
+  let jksFilePath: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipthis-keystore-test-'))
+    jksFilePath = path.join(workDir, 'keyStore.jks')
+    fs.writeFileSync(jksFilePath, 'not-a-real-keystore')
+    process.chdir(workDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(workDir, {force: true, recursive: true})
+  })
+
+  it('removes the generated zip when the import rejects', async () => {
+    await expectRejection(
+      importKeystore({
+        gameId: 'test-game-id',
+        jksFilePath,
+        keyPassword: 'key-password',
+        keystorePassword: 'keystore-password',
+      }),
+    )
+
+    // The generated zip holds the keystore and both passwords in plaintext
+    expect(generatedZips(workDir)).to.deep.equal([])
+  })
+
+  it('never deletes a caller supplied zip when the import rejects', async () => {
+    const callerZip = path.join(workDir, 'my-own-keystore.zip')
+    fs.writeFileSync(callerZip, 'caller supplied zip')
+
+    await expectRejection(importKeystore({gameId: 'test-game-id', zipFilePath: callerZip}))
+
+    expect(fs.existsSync(callerZip)).to.equal(true)
+  })
+
+  it('rejects rather than hanging when the zip cannot be written', async () => {
+    await expectRejection(
+      importKeystore({
+        gameId: 'test-game-id',
+        jksFilePath: path.join(workDir, 'does-not-exist.jks'),
+        keyPassword: 'key-password',
+        keystorePassword: 'keystore-password',
+      }),
+    )
+
+    expect(generatedZips(workDir)).to.deep.equal([])
+  })
+})


### PR DESCRIPTION
Resolves #232 

## What's changed

- Adding try catch finally to the keystore import process
- Correctly cleaning up in the finally
- AI generated tests for the importKeystore zip handling

## Tests done

```bash
shipthis game create --name "TestKeystoreExport" --androidPackageName com.shipthis.test.keystore.export
shipthis game android keyStore create
shipthis game android keyStore export keystore.zip
shipthis game android keyStore import keystore.zip  --force
shipthis game android keyStore import --jksFile keystore/keyStore.jks --keystorePassword 8d702c22-25a2-4c72-8c40-f20f22323dfc --keyPassword 8d702c22-25a2-4c72-8c40-f20f22323dfc --force
```
