### PR TITLE
await the call to delete the cert in Apple

### DIFF
--- a/src/commands/apple/certificate/delete.ts
+++ b/src/commands/apple/certificate/delete.ts
@@ -102,7 +102,7 @@ export default class AppleCertificateDelete extends BaseAppleCommand<typeof Appl
     this.log('The iOS Distribution Certificate has been deleted from ShipThis.')
 
     if (revokeInApple && appleCert?.id) {
-      Certificate.deleteAsync(ctx, {id: appleCert.id})
+      await Certificate.deleteAsync(ctx, {id: appleCert.id})
       this.log('The iOS Distribution Certificate has been deleted in Apple.')
     }
 


### PR DESCRIPTION
Resolves #233 

## What's changed
- awaiting the call to the Expo function to delete the apple cert

## To test
`shipthis apple certificate delete --revokeInApple`