### PR TITLE
fix: display job failures instead of throwing a CLIError

### DIFF
--- a/assets/markdown/ship-failure.md.ejs
+++ b/assets/markdown/ship-failure.md.ejs
@@ -1,11 +1,20 @@
 # There was an error shipping your game
 
-**One or more of the jobs to build your game failed.**
+<% if (failures.length === 1) { -%>
+**The <%= failures[0].platform %> build failed (job <%= failures[0].jobId %>).**
+<% } else { -%>
+**<%= failures.length %> of the builds for your game failed.**
+<% } -%>
 
 ## What now?
 
-- **The last 10 lines of the failed jobs are shown below**
-- Check out the full output in the **ShipThis Dashboard** [<%= jobDashboardUrl %>](<%= jobDashboardUrl %>)
+<% if (showLogTail) { -%>
+- **The last <%= tailLength %> lines of each failed job are shown below**
+<% } -%>
+<% failures.forEach(function (failure) { -%>
+- Read the full <%= failure.platform %> log: `<%= failure.logsCommand %>`
+- See the <%= failure.platform %> job in the **ShipThis Dashboard** [<%= failure.dashboardUrl %>](<%= failure.dashboardUrl %>)
+<% }); -%>
 
 ### Need help?
 

--- a/src/commands/game/ship.tsx
+++ b/src/commands/game/ship.tsx
@@ -1,5 +1,6 @@
 import {Flags} from '@oclif/core'
-import {render} from 'ink'
+import chalk from 'chalk'
+import {Instance, render} from 'ink'
 
 import {downloadBuildById, getJob, getSupportedGodotVersions} from '@cli/api/index.js'
 import {BaseGameCommand} from '@cli/baseCommands/baseGameCommand.js'
@@ -129,13 +130,27 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
       process.exit(0)
     }
 
-    const handleError = (e: Error) => {
-      this.error(getErrorMessage(e))
+    // These two run after run() has resolved, so oclif no longer watches for a throw.
+    // this.error() here reaches node as an uncaught exception, and node prints a stack
+    // trace over the message the user needs. Both handlers therefore print the message
+    // themselves and set the exit code.
+    // The instance lives in an object so handleError can reach what render() returns below.
+    const ui: {instance?: Instance} = {}
+
+    // The Ship component has already shown the summary and the job logs
+    const handleJobsFailed = () => {
+      process.exit(1)
     }
 
-    render(
+    const handleError = (e: unknown) => {
+      ui.instance?.unmount()
+      process.stderr.write(`\n${chalk.red('Error:')} ${getErrorMessage(e)}\n`)
+      process.exit(1)
+    }
+
+    ui.instance = render(
       <CommandGame command={this}>
-        <Ship onComplete={handleComplete} onError={handleError} />
+        <Ship onComplete={handleComplete} onError={handleError} onFailure={handleJobsFailed} />
       </CommandGame>,
     )
   }

--- a/src/commands/game/wizard.tsx
+++ b/src/commands/game/wizard.tsx
@@ -1,8 +1,12 @@
 import {Args} from '@oclif/core'
+import chalk from 'chalk'
 import {withFullScreen} from 'fullscreen-ink'
+import {render} from 'ink'
 
 import {BaseAuthenticatedCommand} from '@cli/baseCommands/index.js'
-import {AndroidWizard, Command} from '@cli/components/index.js'
+import {AndroidWizard, Command, ShipFailure} from '@cli/components/index.js'
+import {Job} from '@cli/types/index.js'
+import {JobFailedError, getErrorMessage} from '@cli/utils/errors.js'
 import {isCWDGodotGame} from '@cli/utils/godot.js'
 
 export default class GameWizard extends BaseAuthenticatedCommand<typeof GameWizard> {
@@ -31,10 +35,52 @@ export default class GameWizard extends BaseAuthenticatedCommand<typeof GameWiza
       return this.config.runCommand('game:ios:wizard')
     }
 
-    withFullScreen(
+    // The wizard draws in the alternate screen buffer, which the terminal discards
+    // on exit, so anything worth keeping is printed after the UI closes.
+    const ui: {ink?: ReturnType<typeof withFullScreen>} = {}
+
+    const closeUI = async () => {
+      ui.ink?.instance.unmount()
+      // Resolves once the alternate buffer has closed
+      await ui.ink?.waitUntilExit()
+    }
+
+    const handleComplete = async () => {
+      await closeUI()
+      process.exit(0)
+    }
+
+    // Runs after run() resolved, so this.error() would reach node as an uncaught
+    // exception and kill the process before the buffer closes.
+    const handleError = async (error: Error) => {
+      await closeUI()
+      if (error instanceof JobFailedError) await this.showJobFailure(error.job)
+      else process.stderr.write(`\n${chalk.red('Error:')} ${getErrorMessage(error)}\n`)
+      process.exit(1)
+    }
+
+    ui.ink = withFullScreen(
       <Command command={this}>
-        <AndroidWizard onComplete={() => process.exit(0)} onError={(e) => this.error(e.message, {exit: 1})} />
+        <AndroidWizard onComplete={handleComplete} onError={handleError} />
       </Command>,
-    ).start()
+    )
+    await ui.ink.start()
+  }
+
+  // The same summary `game ship` shows, in the normal buffer so it survives the exit
+  private async showJobFailure(job: Job): Promise<void> {
+    const failureUI = render(
+      <Command command={this}>
+        <ShipFailure
+          failedJobs={[job]}
+          gameId={job.project.id}
+          onLogsLoaded={() => failureUI.unmount()}
+          showLogTail={true}
+        />
+      </Command>,
+    )
+
+    // unmount() paints the final frame before it resolves this
+    await failureUI.waitUntilExit()
   }
 }

--- a/src/components/JobLogTail.tsx
+++ b/src/components/JobLogTail.tsx
@@ -1,5 +1,6 @@
 import {Box} from 'ink'
 import Spinner from 'ink-spinner'
+import {useEffect} from 'react'
 
 import {JobLogEntry} from '@cli/types'
 import {JobLogTailProps, useJobLogTail} from '@cli/utils/hooks/index.js'
@@ -7,13 +8,23 @@ import {JobLogTailProps, useJobLogTail} from '@cli/utils/hooks/index.js'
 import {JobLogLine} from './common/JobLogLine.js'
 import {Title} from './common/Title.js'
 
+interface Props extends JobLogTailProps {
+  // Says that the first page has arrived, so a caller that exits can wait for it
+  onLoaded?: () => void
+  // The title names the job when more than one tail is on screen
+  title?: string
+}
 
-export const JobLogTail = (props: JobLogTailProps) => {
+export const JobLogTail = ({onLoaded, title = 'Job Logs', ...props}: Props) => {
   const {data, isLoading} = useJobLogTail(props)
+
+  useEffect(() => {
+    if (!isLoading) onLoaded?.()
+  }, [isLoading])
 
   return (
     <Box flexDirection="column">
-      <Title>Job Logs</Title>
+      <Title>{title}</Title>
       {isLoading && <Spinner type="dots" />}
       <Box flexDirection="column">
         {data.map((log: JobLogEntry) => (

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -11,17 +11,14 @@ import {
   JobProgress,
   JobStatusTable,
   Markdown,
+  ShipFailure,
 } from '@cli/components/index.js'
 import {WEB_URL} from '@cli/constants/config.js'
 import {Job, ShipGameFlags} from '@cli/types/index.js'
 import {getShortUUID, useSafeInput, useShip} from '@cli/utils/index.js'
-import {FAILURE_LOG_TAIL_LENGTH, getPlatformLabel, getShipFailureVars} from '@cli/utils/ship/failure.js'
 
 // Time for ink to paint the last frame before the command exits
 const EXIT_FLUSH_MS = 500
-
-// Longest the exit waits for the failed job logs to arrive
-const LOG_WAIT_MS = 10_000
 
 interface Props {
   onComplete: (completedJobs: Job[]) => void
@@ -44,8 +41,7 @@ export const Ship = ({onComplete, onError, onFailure}: Props): JSX.Element => {
 
   const [isComplete, setIsComplete] = useState<boolean>(false)
 
-  const [loadedTails, setLoadedTails] = useState<string[]>([]) // ids of the failed jobs whose logs have arrived
-  const [gaveUpOnLogs, setGaveUpOnLogs] = useState<boolean>(false)
+  const [areFailureLogsLoaded, setAreFailureLogsLoaded] = useState<boolean>(false) // the failure summary is filled in
 
   // Start the command on mount
   const handleStartOnMount = async () => {
@@ -95,59 +91,35 @@ export const Ship = ({onComplete, onError, onFailure}: Props): JSX.Element => {
     handleJobComplete(job)
   }
 
-  // Each tail fetches its own logs. Follow mode streams them instead, so it waits
-  // for none.
-  const showsLogTail = !(flags?.follow || flags?.dryRun)
-  const tailsToLoad = showsLogTail ? failedJobs.length : 0
-  const tailsAreReady = gaveUpOnLogs || loadedTails.length >= tailsToLoad
+  const handleFailureLogsLoaded = () => setAreFailureLogsLoaded(true)
 
   useEffect(() => {
-    if (!isComplete) return
-    if (failedJobs.length === 0) {
-      const timer = setTimeout(() => onComplete(successJobs), EXIT_FLUSH_MS)
-      return () => clearTimeout(timer)
-    }
-
-    // A tail that never answers must not hold the terminal open
-    const timer = setTimeout(() => setGaveUpOnLogs(true), LOG_WAIT_MS)
+    if (!isComplete || failedJobs.length > 0) return
+    const timer = setTimeout(() => onComplete(successJobs), EXIT_FLUSH_MS)
     return () => clearTimeout(timer)
   }, [isComplete])
 
-  // Exiting on a fixed timer cut the tails off mid-fetch and left a spinner on
-  // screen, so the failure exit waits for them.
+  // Exiting on a fixed timer cut the log tails off mid-fetch and left a spinner
+  // on screen, so the failure exit waits for the summary to fill in.
   useEffect(() => {
-    if (!isComplete || failedJobs.length === 0 || !tailsAreReady) return
+    if (!isComplete || failedJobs.length === 0 || !areFailureLogsLoaded) return
     const timer = setTimeout(() => onFailure(failedJobs), EXIT_FLUSH_MS)
     return () => clearTimeout(timer)
-  }, [isComplete, tailsAreReady])
+  }, [isComplete, areFailureLogsLoaded])
 
   if (!gameId) return <></>
 
-  // In follow mode the logs have already been streamed to the terminal, so the
-  // summary shows without a tail. Without it the run ends on raw build output.
-  const failureSummary = (showLogTail: boolean) => (
-    <>
-      <Markdown filename="ship-failure.md.ejs" templateVars={getShipFailureVars(failedJobs, gameId, {showLogTail})} />
-      {showLogTail && (
-        <Box flexDirection="column" marginTop={1}>
-          {failedJobs.map((fj) => (
-            <JobLogTail
-              isWatching={false}
-              jobId={fj.id}
-              key={fj.id}
-              length={FAILURE_LOG_TAIL_LENGTH}
-              onLoaded={() => setLoadedTails((prev) => (prev.includes(fj.id) ? prev : [...prev, fj.id]))}
-              projectId={fj.project.id}
-              title={`Job logs - ${getPlatformLabel(fj.type)}`}
-            />
-          ))}
-        </Box>
-      )}
-    </>
-  )
-
   if (flags?.follow || flags?.dryRun) {
-    if (isComplete && failedJobs.length > 0) return failureSummary(false)
+    if (isComplete && failedJobs.length > 0) {
+      return (
+        <ShipFailure
+          failedJobs={failedJobs}
+          gameId={gameId}
+          onLogsLoaded={handleFailureLogsLoaded}
+          showLogTail={false}
+        />
+      )
+    }
 
     if (jobs && jobs.length > 0) {
       return (
@@ -194,7 +166,14 @@ export const Ship = ({onComplete, onError, onFailure}: Props): JSX.Element => {
               }}
             />
           )}
-          {failedJobs.length > 0 && failureSummary(true)}
+          {failedJobs.length > 0 && (
+            <ShipFailure
+              failedJobs={failedJobs}
+              gameId={gameId}
+              onLogsLoaded={handleFailureLogsLoaded}
+              showLogTail={true}
+            />
+          )}
         </>
       )}
     </Box>

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -91,8 +91,6 @@ export const Ship = ({onComplete, onError, onFailure}: Props): JSX.Element => {
     handleJobComplete(job)
   }
 
-  const handleFailureLogsLoaded = () => setAreFailureLogsLoaded(true)
-
   useEffect(() => {
     if (!isComplete || failedJobs.length > 0) return
     const timer = setTimeout(() => onComplete(successJobs), EXIT_FLUSH_MS)
@@ -115,7 +113,7 @@ export const Ship = ({onComplete, onError, onFailure}: Props): JSX.Element => {
         <ShipFailure
           failedJobs={failedJobs}
           gameId={gameId}
-          onLogsLoaded={handleFailureLogsLoaded}
+          onLogsLoaded={() => setAreFailureLogsLoaded(true)}
           showLogTail={false}
         />
       )
@@ -170,7 +168,7 @@ export const Ship = ({onComplete, onError, onFailure}: Props): JSX.Element => {
             <ShipFailure
               failedJobs={failedJobs}
               gameId={gameId}
-              onLogsLoaded={handleFailureLogsLoaded}
+              onLogsLoaded={() => setAreFailureLogsLoaded(true)}
               showLogTail={true}
             />
           )}

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -73,23 +73,26 @@ export const Ship = ({onComplete, onError, onFailure}: Props): JSX.Element => {
     }
   })
 
+  // Two platforms that fail together arrive as two websocket messages, and React
+  // batches them. Reading the arrays from the render closure lost one of the two
+  // removals, so the run waited forever for a job that had already finished.
+  const removeJob = (job: Job) => setJobs((prev) => (prev || []).filter((prevJob) => prevJob.id !== job.id))
+
   const handleJobComplete = (job: Job) => {
-    // Add the job to the list of completed jobs
-    setSuccessJobs([...successJobs, job])
-    // Remove the job from the list
-    const newJobs = (jobs || []).filter((prevJob) => prevJob.id !== job.id)
-    setJobs(newJobs)
-    // If there are no jobs left  - we are done
-    if (newJobs.length === 0) {
-      setIsComplete(true)
-    }
+    setSuccessJobs((prev) => [...prev, job])
+    removeJob(job)
   }
 
   const handleJobFailure = (job: Job) => {
-    // Add the job to the list of failed jobs
-    setFailedJobs([...failedJobs, job])
-    handleJobComplete(job)
+    setFailedJobs((prev) => [...prev, job])
+    removeJob(job)
   }
+
+  // Derived, because a removal can no longer see the array it produced. `jobs` is
+  // null until the jobs start, and a dry run exits before it is set.
+  useEffect(() => {
+    if (jobs !== null && jobs.length === 0) setIsComplete(true)
+  }, [jobs])
 
   useEffect(() => {
     if (!isComplete || failedJobs.length > 0) return

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -15,13 +15,21 @@ import {
 import {WEB_URL} from '@cli/constants/config.js'
 import {Job, ShipGameFlags} from '@cli/types/index.js'
 import {getShortUUID, useSafeInput, useShip} from '@cli/utils/index.js'
+import {FAILURE_LOG_TAIL_LENGTH, getPlatformLabel, getShipFailureVars} from '@cli/utils/ship/failure.js'
+
+// Time for ink to paint the last frame before the command exits
+const EXIT_FLUSH_MS = 500
+
+// Longest the exit waits for the failed job logs to arrive
+const LOG_WAIT_MS = 10_000
 
 interface Props {
   onComplete: (completedJobs: Job[]) => void
   onError: (error: any) => void
+  onFailure: (failedJobs: Job[]) => void
 }
 
-export const Ship = ({onComplete, onError}: Props): JSX.Element => {
+export const Ship = ({onComplete, onError, onFailure}: Props): JSX.Element => {
   const {command} = useContext(CommandContext)
   const flags = command && (command.getFlags() as ShipGameFlags)
   const {gameId} = useContext(GameContext)
@@ -35,6 +43,9 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
   const [showLog, setShowLog] = useState<boolean>(false)
 
   const [isComplete, setIsComplete] = useState<boolean>(false)
+
+  const [loadedTails, setLoadedTails] = useState<string[]>([]) // ids of the failed jobs whose logs have arrived
+  const [gaveUpOnLogs, setGaveUpOnLogs] = useState<boolean>(false)
 
   // Start the command on mount
   const handleStartOnMount = async () => {
@@ -84,16 +95,60 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
     handleJobComplete(job)
   }
 
+  // Each tail fetches its own logs. Follow mode streams them instead, so it waits
+  // for none.
+  const showsLogTail = !(flags?.follow || flags?.dryRun)
+  const tailsToLoad = showsLogTail ? failedJobs.length : 0
+  const tailsAreReady = gaveUpOnLogs || loadedTails.length >= tailsToLoad
+
   useEffect(() => {
     if (!isComplete) return
-    setTimeout(() => {
-      failedJobs.length === 0 ? onComplete(successJobs) : onError('One or more jobs failed')
-    }, 500)
+    if (failedJobs.length === 0) {
+      const timer = setTimeout(() => onComplete(successJobs), EXIT_FLUSH_MS)
+      return () => clearTimeout(timer)
+    }
+
+    // A tail that never answers must not hold the terminal open
+    const timer = setTimeout(() => setGaveUpOnLogs(true), LOG_WAIT_MS)
+    return () => clearTimeout(timer)
   }, [isComplete])
+
+  // Exiting on a fixed timer cut the tails off mid-fetch and left a spinner on
+  // screen, so the failure exit waits for them.
+  useEffect(() => {
+    if (!isComplete || failedJobs.length === 0 || !tailsAreReady) return
+    const timer = setTimeout(() => onFailure(failedJobs), EXIT_FLUSH_MS)
+    return () => clearTimeout(timer)
+  }, [isComplete, tailsAreReady])
 
   if (!gameId) return <></>
 
+  // In follow mode the logs have already been streamed to the terminal, so the
+  // summary shows without a tail. Without it the run ends on raw build output.
+  const failureSummary = (showLogTail: boolean) => (
+    <>
+      <Markdown filename="ship-failure.md.ejs" templateVars={getShipFailureVars(failedJobs, gameId, {showLogTail})} />
+      {showLogTail && (
+        <Box flexDirection="column" marginTop={1}>
+          {failedJobs.map((fj) => (
+            <JobLogTail
+              isWatching={false}
+              jobId={fj.id}
+              key={fj.id}
+              length={FAILURE_LOG_TAIL_LENGTH}
+              onLoaded={() => setLoadedTails((prev) => (prev.includes(fj.id) ? prev : [...prev, fj.id]))}
+              projectId={fj.project.id}
+              title={`Job logs - ${getPlatformLabel(fj.type)}`}
+            />
+          ))}
+        </Box>
+      )}
+    </>
+  )
+
   if (flags?.follow || flags?.dryRun) {
+    if (isComplete && failedJobs.length > 0) return failureSummary(false)
+
     if (jobs && jobs.length > 0) {
       return (
         <JobFollow jobId={jobs[0].id} onComplete={handleJobComplete} onFailure={handleJobFailure} projectId={gameId} />
@@ -139,21 +194,7 @@ export const Ship = ({onComplete, onError}: Props): JSX.Element => {
               }}
             />
           )}
-          {failedJobs.length > 0 && (
-            <>
-              <Markdown
-                filename="ship-failure.md.ejs"
-                templateVars={{
-                  jobDashboardUrl: `${WEB_URL}games/${getShortUUID(gameId)}/job/${getShortUUID(failedJobs[0].id)}`,
-                }}
-              />
-              <Box marginTop={1}>
-                {failedJobs.map((fj) => (
-                  <JobLogTail isWatching={false} jobId={fj.id} key={fj.id} length={10} projectId={fj.project.id} />
-                ))}
-              </Box>
-            </>
-          )}
+          {failedJobs.length > 0 && failureSummary(true)}
         </>
       )}
     </Box>

--- a/src/components/ShipFailure.tsx
+++ b/src/components/ShipFailure.tsx
@@ -15,7 +15,7 @@ interface Props {
   gameId: string
   // Says every log the summary will show has arrived, so a caller that exits
   // can wait for it
-  onLogsLoaded: () => void
+  onLogsLoaded?: () => void
   // Follow mode has already streamed the logs to the terminal, so it shows the
   // summary without a tail. Without the summary the run ends on raw build output.
   showLogTail: boolean
@@ -44,7 +44,7 @@ export const ShipFailure = ({failedJobs, gameId, onLogsLoaded, showLogTail}: Pro
   }, [])
 
   useEffect(() => {
-    if (areLogsLoaded) onLogsLoaded()
+    if (areLogsLoaded) onLogsLoaded?.()
   }, [areLogsLoaded])
 
   return (

--- a/src/components/ShipFailure.tsx
+++ b/src/components/ShipFailure.tsx
@@ -1,0 +1,70 @@
+import {Box} from 'ink'
+import {useEffect, useState} from 'react'
+
+import {Job} from '@cli/types/index.js'
+import {FAILURE_LOG_TAIL_LENGTH, getPlatformLabel, getShipFailureVars} from '@cli/utils/ship/failure.js'
+
+import {Markdown} from './common/Markdown.js'
+import {JobLogTail} from './JobLogTail.js'
+
+// Longest we wait for the failed job logs to arrive
+const LOG_WAIT_MS = 10_000
+
+interface Props {
+  failedJobs: Job[]
+  gameId: string
+  // Says every log the summary will show has arrived, so a caller that exits
+  // can wait for it
+  onLogsLoaded: () => void
+  // Follow mode has already streamed the logs to the terminal, so it shows the
+  // summary without a tail. Without the summary the run ends on raw build output.
+  showLogTail: boolean
+}
+
+export const ShipFailure = ({failedJobs, gameId, onLogsLoaded, showLogTail}: Props): JSX.Element => {
+  const [loadedTailIds, setLoadedTailIds] = useState<Set<string>>(new Set())
+  const [gaveUpOnLogs, setGaveUpOnLogs] = useState<boolean>(false)
+
+  // A set, because two tails can report in the same tick and the count must not
+  // double for one job
+  const handleTailLoaded = (jobId: string) => {
+    setLoadedTailIds((prev) => new Set(prev).add(jobId))
+  }
+
+  // Each tail fetches its own logs, and exiting mid-fetch leaves a spinner on
+  // screen. With no tail there is nothing to wait for.
+  const tailsToLoad = showLogTail ? failedJobs.length : 0
+  const areLogsLoaded = gaveUpOnLogs || loadedTailIds.size >= tailsToLoad
+
+  useEffect(() => {
+    if (tailsToLoad === 0) return
+    // A tail that never answers must not hold the terminal open
+    const timer = setTimeout(() => setGaveUpOnLogs(true), LOG_WAIT_MS)
+    return () => clearTimeout(timer)
+  }, [])
+
+  useEffect(() => {
+    if (areLogsLoaded) onLogsLoaded()
+  }, [areLogsLoaded])
+
+  return (
+    <>
+      <Markdown filename="ship-failure.md.ejs" templateVars={getShipFailureVars(failedJobs, gameId, {showLogTail})} />
+      {showLogTail && (
+        <Box flexDirection="column" marginTop={1}>
+          {failedJobs.map((fj) => (
+            <JobLogTail
+              isWatching={false}
+              jobId={fj.id}
+              key={fj.id}
+              length={FAILURE_LOG_TAIL_LENGTH}
+              onLoaded={() => handleTailLoaded(fj.id)}
+              projectId={fj.project.id}
+              title={`Job logs - ${getPlatformLabel(fj.type)}`}
+            />
+          ))}
+        </Box>
+      )}
+    </>
+  )
+}

--- a/src/components/ShipFailure.tsx
+++ b/src/components/ShipFailure.tsx
@@ -15,7 +15,7 @@ interface Props {
   gameId: string
   // Says every log the summary will show has arrived, so a caller that exits
   // can wait for it
-  onLogsLoaded?: () => void
+  onLogsLoaded: () => void
   // Follow mode has already streamed the logs to the terminal, so it shows the
   // summary without a tail. Without the summary the run ends on raw build output.
   showLogTail: boolean
@@ -44,7 +44,7 @@ export const ShipFailure = ({failedJobs, gameId, onLogsLoaded, showLogTail}: Pro
   }, [])
 
   useEffect(() => {
-    if (areLogsLoaded) onLogsLoaded?.()
+    if (areLogsLoaded) onLogsLoaded()
   }, [areLogsLoaded])
 
   return (

--- a/src/components/android/AndroidWizard/index.tsx
+++ b/src/components/android/AndroidWizard/index.tsx
@@ -69,7 +69,7 @@ export const AndroidWizard = (props: StepProps) => {
 
   const handleError = (e: Error) => {
     setError(e)
-    setTimeout(() => process.exit(1), ON_COMPLETE_DELAY_MS)
+    setTimeout(() => props.onError(e), ON_COMPLETE_DELAY_MS)
   }
 
   const StepInterface = currentStep ? stepComponentMap[currentStep] : null

--- a/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
+++ b/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
@@ -2,9 +2,9 @@ import {Box, Text} from 'ink'
 import Spinner from 'ink-spinner'
 import {useContext, useEffect, useRef, useState} from 'react'
 
-import {CommandContext, JobLogTail, JobProgress, ShipFailure, StepProps} from '@cli/components/index.js'
+import {CommandContext, JobLogTail, JobProgress, StepProps} from '@cli/components/index.js'
 import {BuildType, Job, JobStatus, Platform} from '@cli/types/api.js'
-import {useBuilds, useJobs, useShip} from '@cli/utils/index.js'
+import {JobFailedError, useBuilds, useJobs, useShip} from '@cli/utils/index.js'
 
 export interface InitialAndroidBuildProps extends StepProps {
   gameId: string
@@ -20,8 +20,6 @@ export const InitialAndroidBuild = ({gameId, onComplete, onError, ...boxProps}: 
   const prevHasBuild = useRef<boolean>(false)
   const shipMutation = useShip()
   const [shipLog, setShipLog] = useState<string>('')
-  const [failedJob, setFailedJob] = useState<Job | null>(null)
-  const [failedJobError, setFailedJobError] = useState<Error | null>(null)
 
   // Trigger a build if we don't have one
   useEffect(() => {
@@ -55,12 +53,6 @@ export const InitialAndroidBuild = ({gameId, onComplete, onError, ...boxProps}: 
         .catch(onError)
   }, [buildData, jobData, command])
 
-  // Exiting on a fixed timer cut the log tail off mid-fetch, so onError waits
-  // for the ShipFailure summary to finish loading its logs.
-  useEffect(() => {
-    if (failedJobError) onError(failedJobError)
-  }, [failedJobError, onError])
-
   const androidJob = jobData?.data.find(
     (job) => job.type === Platform.ANDROID && [JobStatus.PENDING, JobStatus.PROCESSING].includes(job.status),
   )
@@ -78,21 +70,10 @@ export const InitialAndroidBuild = ({gameId, onComplete, onError, ...boxProps}: 
             <JobProgress
               job={androidJob}
               onComplete={onComplete}
-              onFailure={(j: Job) => {
-                setFailedJob(j)
-              }}
+              onFailure={(j: Job) => onError(new JobFailedError(j))}
             />
             <JobLogTail isWatching={true} jobId={androidJob.id} length={10} projectId={gameId} />
           </>
-        )}
-
-        {failedJob && (
-          <ShipFailure
-            failedJobs={[failedJob]}
-            gameId={gameId}
-            onLogsLoaded={() => setFailedJobError(new Error(`Job ${failedJob.id} failed`))}
-            showLogTail={true}
-          />
         )}
       </Box>
     </>

--- a/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
+++ b/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
@@ -21,6 +21,7 @@ export const InitialAndroidBuild = ({gameId, onComplete, onError, ...boxProps}: 
   const shipMutation = useShip()
   const [shipLog, setShipLog] = useState<string>('')
   const [failedJob, setFailedJob] = useState<Job | null>(null)
+  const [failedJobError, setFailedJobError] = useState<Error | null>(null)
 
   // Trigger a build if we don't have one
   useEffect(() => {
@@ -54,6 +55,12 @@ export const InitialAndroidBuild = ({gameId, onComplete, onError, ...boxProps}: 
         .catch(onError)
   }, [buildData, jobData, command])
 
+  // Exiting on a fixed timer cut the log tail off mid-fetch, so onError waits
+  // for the ShipFailure summary to finish loading its logs.
+  useEffect(() => {
+    if (failedJobError) onError(failedJobError)
+  }, [failedJobError, onError])
+
   const androidJob = jobData?.data.find(
     (job) => job.type === Platform.ANDROID && [JobStatus.PENDING, JobStatus.PROCESSING].includes(job.status),
   )
@@ -73,17 +80,20 @@ export const InitialAndroidBuild = ({gameId, onComplete, onError, ...boxProps}: 
               onComplete={onComplete}
               onFailure={(j: Job) => {
                 setFailedJob(j)
-                // Wait before triggering the error to allow the job log to be displayed
-                setTimeout(() => {
-                  onError(new Error(`Job ${j.id} failed`))
-                }, 1000)
               }}
             />
             <JobLogTail isWatching={true} jobId={androidJob.id} length={10} projectId={gameId} />
           </>
         )}
 
-        {failedJob && <ShipFailure failedJobs={[failedJob]} gameId={gameId} showLogTail={true} />}
+        {failedJob && (
+          <ShipFailure
+            failedJobs={[failedJob]}
+            gameId={gameId}
+            onLogsLoaded={() => setFailedJobError(new Error(`Job ${failedJob.id} failed`))}
+            showLogTail={true}
+          />
+        )}
       </Box>
     </>
   )

--- a/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
+++ b/src/components/android/CreateInitialBuild/InitialAndroidBuild.tsx
@@ -2,10 +2,9 @@ import {Box, Text} from 'ink'
 import Spinner from 'ink-spinner'
 import {useContext, useEffect, useRef, useState} from 'react'
 
-import {CommandContext, JobLogTail, JobProgress, Markdown, StepProps} from '@cli/components/index.js'
-import {WEB_URL} from '@cli/constants/config.js'
+import {CommandContext, JobLogTail, JobProgress, ShipFailure, StepProps} from '@cli/components/index.js'
 import {BuildType, Job, JobStatus, Platform} from '@cli/types/api.js'
-import {getShortUUID, useBuilds, useJobs, useShip} from '@cli/utils/index.js'
+import {useBuilds, useJobs, useShip} from '@cli/utils/index.js'
 
 export interface InitialAndroidBuildProps extends StepProps {
   gameId: string
@@ -84,19 +83,7 @@ export const InitialAndroidBuild = ({gameId, onComplete, onError, ...boxProps}: 
           </>
         )}
 
-        {failedJob && (
-          <>
-            <Markdown
-              filename="ship-failure.md.ejs"
-              templateVars={{
-                jobDashboardUrl: `${WEB_URL}games/${getShortUUID(gameId)}/job/${getShortUUID(failedJob.id)}`,
-              }}
-            />
-            <Box marginTop={1}>
-              <JobLogTail isWatching={false} jobId={failedJob.id} length={10} projectId={gameId} />
-            </Box>
-          </>
-        )}
+        {failedJob && <ShipFailure failedJobs={[failedJob]} gameId={gameId} showLogTail={true} />}
       </Box>
     </>
   )

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -7,6 +7,7 @@ export * from './JobStatusTable.js'
 export * from './ProjectCredentialsTable.js'
 
 export * from './Ship.js'
+export * from './ShipFailure.js'
 export * from './UserCredentialsTable.js'
 export * from './android/index.js'
 export * from './apple/index.js'

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,6 @@
 import Axios from 'axios'
 
-import {HandledError} from '@cli/types/index.js'
+import {HandledError, Job} from '@cli/types/index.js'
 
 import {getShortUUID} from './uuid.js'
 
@@ -51,6 +51,16 @@ export function isRetryable(error: unknown) {
   // No status means the request never got an answer, which is worth another try
   if (status === undefined) return true
   return status >= 500 || RETRYABLE_CLIENT_STATUSES.includes(status)
+}
+
+// Carries the job, so a caller outside the wizard can show its logs. The wizard
+// draws in the alternate screen buffer, which the terminal discards on exit, so
+// the failure summary has to be printed after that buffer closes.
+export class JobFailedError extends Error {
+  constructor(public readonly job: Job) {
+    super(`Job ${getShortUUID(job.id)} failed`)
+    this.name = 'JobFailedError'
+  }
 }
 
 // Util to extract API error messages if present

--- a/src/utils/ship/failure.ts
+++ b/src/utils/ship/failure.ts
@@ -1,0 +1,45 @@
+import {WEB_URL} from '@cli/constants/config.js'
+import {Job, Platform} from '@cli/types'
+import {getShortUUID} from '@cli/utils/uuid.js'
+
+// The last 10 lines of an iOS build hold the fastlane summary table, not the
+// error that caused it. 25 lines reaches back past the table.
+export const FAILURE_LOG_TAIL_LENGTH = 25
+
+// One failed job, in the form ship-failure.md.ejs needs
+export interface ShipFailure {
+  dashboardUrl: string
+  jobId: string
+  logsCommand: string
+  platform: string
+}
+
+export interface ShipFailureVars {
+  failures: ShipFailure[]
+  showLogTail: boolean
+  tailLength: number
+}
+
+export function getPlatformLabel(platform: Platform): string {
+  return platform === Platform.IOS ? 'iOS' : 'Android'
+}
+
+// Builds the variables for ship-failure.md.ejs. Every failed job gets its own log
+// command and dashboard link - when both platforms fail, one link is not enough.
+export function getShipFailureVars(
+  failedJobs: Job[],
+  gameId: string,
+  {showLogTail, tailLength = FAILURE_LOG_TAIL_LENGTH}: {showLogTail: boolean; tailLength?: number},
+): ShipFailureVars {
+  const failures = failedJobs.map((job) => {
+    const jobId = getShortUUID(job.id)
+    return {
+      dashboardUrl: `${WEB_URL}games/${getShortUUID(gameId)}/job/${jobId}`,
+      jobId,
+      logsCommand: `shipthis game job logs ${jobId}`,
+      platform: getPlatformLabel(job.type),
+    }
+  })
+
+  return {failures, showLogTail, tailLength}
+}

--- a/test/utils/ship/failure.test.ts
+++ b/test/utils/ship/failure.test.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import {expect} from 'chai'
+import ejs from 'ejs'
+
+import {Job, Platform} from '@cli/types'
+import {getShipFailureVars} from '@cli/utils/ship/failure.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const templatePath = path.join(__dirname, '../../../assets/markdown/ship-failure.md.ejs')
+
+const GAME_ID = 'b8b2701f-6b77-4e5b-82e0-4518619fb5c4'
+const IOS_JOB_ID = 'e69a082b-4e33-4676-bd53-b8cfc28e2d7d'
+const ANDROID_JOB_ID = '21702a3b-1111-2222-3333-444455556666'
+
+const makeJob = (id: string, type: Platform) => ({id, type}) as Job
+
+// Renders the real template, so the test fails if the two stop agreeing
+const render = (failedJobs: Job[], showLogTail: boolean) => {
+  const template = fs.readFileSync(templatePath, 'utf8')
+  const vars = getShipFailureVars(failedJobs, GAME_ID, {showLogTail})
+  return {text: ejs.render(template, vars), vars}
+}
+
+describe('getShipFailureVars (utils/ship/failure)', () => {
+  it('shortens the ids and names the platform', () => {
+    const {failures} = getShipFailureVars([makeJob(IOS_JOB_ID, Platform.IOS)], GAME_ID, {showLogTail: true})
+
+    expect(failures).to.have.length(1)
+    expect(failures[0].jobId).to.equal('e69a082b')
+    expect(failures[0].platform).to.equal('iOS')
+    expect(failures[0].logsCommand).to.equal('shipthis game job logs e69a082b')
+    expect(failures[0].dashboardUrl).to.contain('games/b8b2701f/job/e69a082b')
+  })
+
+  it('describes every failed job, not only the first', () => {
+    const jobs = [makeJob(IOS_JOB_ID, Platform.IOS), makeJob(ANDROID_JOB_ID, Platform.ANDROID)]
+    const {failures} = getShipFailureVars(jobs, GAME_ID, {showLogTail: true})
+
+    expect(failures.map((f) => f.platform)).to.deep.equal(['iOS', 'Android'])
+    expect(failures.map((f) => f.jobId)).to.deep.equal(['e69a082b', '21702a3b'])
+  })
+})
+
+describe('ship-failure.md.ejs', () => {
+  it('names the platform and the job that failed', () => {
+    const {text} = render([makeJob(IOS_JOB_ID, Platform.IOS)], true)
+
+    expect(text).to.contain('The iOS build failed (job e69a082b).')
+    expect(text).to.contain('shipthis game job logs e69a082b')
+  })
+
+  it('promises the log tail only when a tail follows', () => {
+    const jobs = [makeJob(IOS_JOB_ID, Platform.IOS)]
+
+    expect(render(jobs, true).text).to.contain('The last 25 lines')
+    expect(render(jobs, false).text).to.not.contain('lines of each failed job')
+  })
+
+  it('links every failed job to the dashboard', () => {
+    const jobs = [makeJob(IOS_JOB_ID, Platform.IOS), makeJob(ANDROID_JOB_ID, Platform.ANDROID)]
+    const {text, vars} = render(jobs, false)
+
+    expect(text).to.contain('2 of the builds for your game failed.')
+    for (const failure of vars.failures) {
+      expect(text).to.contain(failure.dashboardUrl)
+      expect(text).to.contain(failure.logsCommand)
+    }
+  })
+
+  it('keeps the help links', () => {
+    const {text} = render([makeJob(IOS_JOB_ID, Platform.IOS)], true)
+
+    expect(text).to.contain('https://discord.gg/HuSvK4GT')
+    expect(text).to.contain('https://github.com/shipth-is/cli/issues')
+  })
+})


### PR DESCRIPTION
This is to resolve #248 

## What's changed

- Better failure template including the `shipthis game job logs` command
- Showing 25 lines instead of 10
- Don't show the log lines in follow mode (already shown)
- Fixing bug where command would exit before last log lines shown
- Separate `ShipFailure` component

## Example - `shipthis game ship`

```bash
david@sal9000:~/game$ shipthis game ship --platform ios
# There was an error shipping your game

The iOS build failed (job 8dd796e7).

## What now?

    * The last 25 lines of each failed job are shown below
    * Read the full iOS log: shipthis game job logs 8dd796e7
    * See the iOS job in the ShipThis Dashboard https://develop.shipth.is/games/b8b2701f/job/8dd796e7

### Need help?

    * Join the Discord https://discord.gg/HuSvK4GT
    * Report an issue https://github.com/shipth-is/cli/issues

JOB LOGS - IOS
11:09:32.588 BUILD     [10:09:32]:  => 218:         bui
11:09:32.589 BUILD     [10:09:32]:     219:           workspace: use_workspace ? ENV['WORKSPACE_PATH']
11:09:32.590 BUILD     [10:09:32]:     220:	      project: !use_workspace ? ENV['PROJECT_PATH']
11:09:32.591 BUILD     [10:09:32]: ```
11:09:32.592 BUILD     +---------------------------------------------+
11:09:32.593 BUILD     |              fastlane summary               |
11:09:32.594 BUILD     +------+------------------------+-------------+
11:09:32.595 BUILD     | Step | Action                 | Time (in s) |
11:09:32.596 BUILD     +------+------------------------+-------------+
11:09:32.597 BUILD     | 1    | default_platform       | 0           |
11:09:32.598 BUILD     | 2    | import_certificate     | 0           |
11:09:32.599 BUILD     | 3    | install_provisioning_  | 0           |
11:09:32.600 BUILD     |      | profile                |             |
11:09:32.601 BUILD     | 4    | update_code_signing_s  | 0           |
11:09:32.602 BUILD     |      | ettings                |             |
11:09:32.603 BUILD     | 5    | update_project_provis  | 0           |
11:09:32.604 BUILD     |      | ioning                 |             |
11:09:32.605 BUILD     | 6    | update_project_team    | 0           |
11:09:32.606 BUILD     | 💥   | build_app              | 5           |
11:09:32.607 BUILD     +------+------------------------+-------------+
11:09:32.608 BUILD     [10:09:32]: fastlane finished with errors
11:09:32.991 BUILD     Fastlane failed, but continuing script
11:09:32.992 BUILD     Resetting default keychain to /Library/Keychains/System.keychain
11:09:34.033 BUILD     Failed to run the build script
11:09:34.034 SETUP     Failed to run the build script
david@sal9000:~/game$ 
```

## Example - `shipthis game ship --platform ios --follow`

```bash
.... TRIMMED ...
[10:14:32]:     216:        end
[10:14:32]:     217:
[10:14:32]:  => 218:        build_app(
[10:14:32]:     219:          workspace: use_workspace ? ENV['WORKSPACE_PATH'] : nil,
[10:14:32]:     220:          project: !use_workspace ? ENV['PROJECT_PATH'] : nil,
[10:14:32]: ```
+---------------------------------------------+
|              fastlane summary               |
+------+------------------------+-------------+
| Step | Action                 | Time (in s) |
+------+------------------------+-------------+
| 1    | default_platform       | 0           |
| 2    | import_certificate     | 0           |
| 3    | install_provisioning_  | 0           |
|      | profile                |             |
| 4    | update_code_signing_s  | 0           |
|      | ettings                |             |
| 5    | update_project_provis  | 0           |
|      | ioning                 |             |
| 6    | update_project_team    | 0           |
| 💥   | build_app              | 5           |
+------+------------------------+-------------+
[10:14:32]: fastlane finished with errors
Fastlane failed, but continuing script
Resetting default keychain to /Library/Keychains/System.keychain
Failed to run the build script
Failed to run the build script
# There was an error shipping your game

The iOS build failed (job b4d5673d).

## What now?

    * Read the full iOS log: shipthis game job logs b4d5673d
    * See the iOS job in the ShipThis Dashboard https://develop.shipth.is/games/b8b2701f/job/b4d5673d

### Need help?

    * Join the Discord https://discord.gg/HuSvK4GT
    * Report an issue https://github.com/shipth-is/cli/issues
david@sal9000:~/game$ 

```
