### PR TITLE
fix: better error messages when game has not been configured

### DIFF
--- a/src/baseCommands/baseCommand.ts
+++ b/src/baseCommands/baseCommand.ts
@@ -37,15 +37,16 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     }
 
     if (!this.hasProjectConfig()) {
-      this.errorNoGame()
+      // This check is about the directory, so --gameId is no way out of it.
+      this.errorNoGame({needsProjectConfig: true})
     }
   }
 
   // `never` is load-bearing. Two callers read the game ID after this line, and TypeScript
   // narrows it out of `null` only because this returns `never`.
-  protected errorNoGame(): never {
+  protected errorNoGame(options: {needsProjectConfig?: boolean} = {}): never {
     const {platform} = this.flags as {platform?: string}
-    const {message, ref, suggestions} = getNoGameError(this.getCommandName(), platform)
+    const {message, ref, suggestions} = getNoGameError(this.getCommandName(), platform, options)
     this.error(message, {exit: 1, ref, suggestions})
   }
 

--- a/src/baseCommands/baseCommand.ts
+++ b/src/baseCommands/baseCommand.ts
@@ -9,7 +9,7 @@ import {getSelf, setAuthToken} from '@cli/api/index.js'
 import {Auth} from '@cli/apple/expo.js'
 import {AUTH_ENV_VAR_NAME, DetailsFlags} from '@cli/constants/index.js'
 import {AuthConfig, ProjectConfig} from '@cli/types'
-import {isCWDGodotGame} from '@cli/utils/index.js'
+import {getNoGameError, isCWDGodotGame} from '@cli/utils/index.js'
 
 export type Flags<T extends typeof Command> = Interfaces.InferredFlags<(typeof BaseCommand)['baseFlags'] & T['flags']>
 export type Args<T extends typeof Command> = Interfaces.InferredArgs<T['args']>
@@ -37,11 +37,16 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     }
 
     if (!this.hasProjectConfig()) {
-      this.error(
-        'No ShipThis config found. Please run `shipthis game create --name "Space Invaders"` to create a game.',
-        {exit: 1},
-      )
+      this.errorNoGame()
     }
+  }
+
+  // `never` is load-bearing. Two callers read the game ID after this line, and TypeScript
+  // narrows it out of `null` only because this returns `never`.
+  protected errorNoGame(): never {
+    const {platform} = this.flags as {platform?: string}
+    const {message, ref, suggestions} = getNoGameError(this.getCommandName(), platform)
+    this.error(message, {exit: 1, ref, suggestions})
   }
 
   protected ensureWeHaveAppleCookies(): void {
@@ -107,6 +112,13 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     }
 
     return values
+  }
+
+  // "shipthis game status" - the command the user typed, for a suggestion.
+  // `id` is `string | undefined` on the oclif Command, and an empty name drops that suggestion.
+  public getCommandName(): string {
+    if (!this.id) return ''
+    return [this.config.bin, ...this.id.split(':')].join(' ')
   }
 
   // Exposing it to the react components using the CommandContext

--- a/src/baseCommands/baseGameCommand.ts
+++ b/src/baseCommands/baseGameCommand.ts
@@ -14,7 +14,7 @@ export abstract class BaseGameCommand<T extends typeof Command> extends BaseAuth
   public async getGame(): Promise<Project> {
     try {
       const gameId = await this.getGameId()
-      if (!gameId) this.error('No game ID found.')
+      if (!gameId) this.errorNoGame()
       return await getProject(gameId)
     } catch (error: any) {
       if (error instanceof HandledError) {

--- a/src/commands/game/list.tsx
+++ b/src/commands/game/list.tsx
@@ -4,6 +4,7 @@ import {Box, Text, render} from 'ink'
 import {getProjects} from '@cli/api/index.js'
 import {BaseAuthenticatedCommand} from '@cli/baseCommands/index.js'
 import {Command, Table} from '@cli/components/index.js'
+import {WIZARD_COMMANDS} from '@cli/constants/commands.js'
 import {PageAndSortParams} from '@cli/types'
 import {getShortDate} from '@cli/utils/dates.js'
 import {getShortUUID} from '@cli/utils/index.js'
@@ -52,8 +53,9 @@ export default class GameList extends BaseAuthenticatedCommand<typeof GameList> 
           <Box flexDirection="column">
             <Text>No games found. Create one now with:</Text>
             <Box flexDirection="column" marginLeft={2} marginTop={1}>
-              <Text>shipthis game wizard android</Text>
-              <Text>shipthis game wizard ios</Text>
+              {WIZARD_COMMANDS.map((command) => (
+                <Text key={command}>{command}</Text>
+              ))}
             </Box>
           </Box>
         )}

--- a/src/commands/game/ship.tsx
+++ b/src/commands/game/ship.tsx
@@ -99,7 +99,8 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
     await this.ensureWeAreInAProjectDir()
     const gameId = this.getGameId()
     if (!gameId) {
-      this.errorNoGame()
+      // ship() reads the game from shipthis.json, never from --gameId.
+      this.errorNoGame({needsProjectConfig: true})
     }
 
     const MAX_RETRIES = 3

--- a/src/commands/game/ship.tsx
+++ b/src/commands/game/ship.tsx
@@ -99,7 +99,7 @@ export default class GameShip extends BaseGameCommand<typeof GameShip> {
     await this.ensureWeAreInAProjectDir()
     const gameId = this.getGameId()
     if (!gameId) {
-      this.error('No game ID found')
+      this.errorNoGame()
     }
 
     const MAX_RETRIES = 3

--- a/src/commands/game/status.tsx
+++ b/src/commands/game/status.tsx
@@ -25,10 +25,7 @@ export default class GameStatus extends BaseAuthenticatedCommand<typeof GameStat
   }
 
   public async run(): Promise<void> {
-    const gameId = this.getGameId()
-    if (!gameId) {
-      this.error('No game found - please run `shipthis game wizard` or specify a game ID with --gameId', {exit: 1})
-    }
+    if (!this.getGameId()) this.errorNoGame()
 
     render(
       <CommandGame command={this}>

--- a/src/commands/status.tsx
+++ b/src/commands/status.tsx
@@ -3,6 +3,7 @@ import {render} from 'ink'
 
 import {BaseCommand} from '@cli/baseCommands/index.js'
 import {Command, NextSteps, StatusTable} from '@cli/components/index.js'
+import {WIZARD_COMMANDS} from '@cli/constants/commands.js'
 import {AuthConfig} from '@cli/types'
 import {isCWDGitRepo, isCWDGodotGame} from '@cli/utils/index.js'
 
@@ -28,7 +29,8 @@ export default class Status extends BaseCommand<typeof Status> {
 
     if (!isLoggedIn) steps.push('shipthis login --email my.email@address.nowhere')
     if (!isGodotGame) steps.push('Run this command in a Godot project directory')
-    if (!isShipThisConfigured) steps.push('shipthis game wizard')
+    // The wizard needs a platform, so both commands go in the list.
+    if (!isShipThisConfigured) steps.push(...WIZARD_COMMANDS)
 
     const exitCode = steps.length > 0 ? 1 : 0
 

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -1,0 +1,6 @@
+// The wizard needs a platform, so there is no bare `shipthis game wizard` to suggest.
+export const WIZARD_COMMANDS = ['shipthis game wizard android', 'shipthis game wizard ios']
+
+export const CREATE_GAME_COMMAND = 'shipthis game create --name "My Game"'
+
+export const CREATE_A_PROJECT_DOCS = 'https://shipth.is/docs/create-a-project'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,7 @@
 import {Flags} from '@oclif/core'
 
 export * from './cacheKeys.js'
+export * from './commands.js'
 export * from './config.js'
 export * from './godot.js'
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -132,21 +132,37 @@ const NO_GAME_MESSAGE =
   'Run the wizard for the platform you want to ship to, or name a game you already have ' +
   'with --gameId. Run `shipthis game list` to see your game IDs.'
 
+// For a command that needs shipthis.json, such as `game ship`. No game ID stands in for it.
+const NO_PROJECT_CONFIG_MESSAGE =
+  'No game is set up in this directory.\nRun the wizard for the platform you want to ship to.'
+
 /**
  * The answer to "there is no game here". `commandName` is the command the user typed, such
- * as "shipthis game status". An empty name drops the --gameId suggestion. `platform` narrows
- * the wizard suggestion to one line.
+ * as "shipthis game status", and an empty name drops the --gameId suggestion. `platform`
+ * narrows the wizard suggestion to one line. `needsProjectConfig` drops --gameId entirely.
  */
-export function getNoGameError(commandName: string, platform?: string): CommandError {
+export function getNoGameError(
+  commandName: string,
+  platform?: string,
+  options: {needsProjectConfig?: boolean} = {},
+): CommandError {
+  const {needsProjectConfig = false} = options
+
   // A command that knows the platform names one wizard. Every other case names both.
   const forPlatform = platform ? WIZARD_COMMANDS.filter((command) => command.endsWith(` ${platform}`)) : []
 
+  // `shipthis --gameId <id>` is not a command, so an empty name drops the line.
+  const showGameId = Boolean(commandName) && !needsProjectConfig
+
   const suggestions = [
     ...(forPlatform.length > 0 ? forPlatform : WIZARD_COMMANDS),
-    // `shipthis --gameId <id>` is not a command, so an empty name drops this line.
-    ...(commandName ? [`${commandName} --gameId <id>`] : []),
+    ...(showGameId ? [`${commandName} --gameId <id>`] : []),
     CREATE_GAME_COMMAND,
   ]
 
-  return {message: NO_GAME_MESSAGE, ref: CREATE_A_PROJECT_DOCS, suggestions}
+  return {
+    message: needsProjectConfig ? NO_PROJECT_CONFIG_MESSAGE : NO_GAME_MESSAGE,
+    ref: CREATE_A_PROJECT_DOCS,
+    suggestions,
+  }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,8 @@
 import Axios from 'axios'
 
+// Imported from the file, not from `constants/index.js` - that builds the oclif flags, and
+// importing it here has caused a circular import before (see 4a7357f).
+import {CREATE_A_PROJECT_DOCS, CREATE_GAME_COMMAND, WIZARD_COMMANDS} from '@cli/constants/commands.js'
 import {HandledError, Job} from '@cli/types/index.js'
 
 import {getShortUUID} from './uuid.js'
@@ -111,4 +114,39 @@ export function toHandledError(error: any, context: {projectId?: string} = {}) {
     default:
       return error
   }
+}
+
+/**
+ * A failure a command reports. The fields match the options `this.error()` takes, so a
+ * caller passes them straight through and oclif prints the suggestions and the reference.
+ */
+export interface CommandError {
+  message: string
+  ref?: string
+  suggestions?: string[]
+}
+
+// One `\n`, after the first sentence. oclif wraps the rest itself.
+const NO_GAME_MESSAGE =
+  'No game is set up in this directory.\n' +
+  'Run the wizard for the platform you want to ship to, or name a game you already have ' +
+  'with --gameId. Run `shipthis game list` to see your game IDs.'
+
+/**
+ * The answer to "there is no game here". `commandName` is the command the user typed, such
+ * as "shipthis game status". An empty name drops the --gameId suggestion. `platform` narrows
+ * the wizard suggestion to one line.
+ */
+export function getNoGameError(commandName: string, platform?: string): CommandError {
+  // A command that knows the platform names one wizard. Every other case names both.
+  const forPlatform = platform ? WIZARD_COMMANDS.filter((command) => command.endsWith(` ${platform}`)) : []
+
+  const suggestions = [
+    ...(forPlatform.length > 0 ? forPlatform : WIZARD_COMMANDS),
+    // `shipthis --gameId <id>` is not a command, so an empty name drops this line.
+    ...(commandName ? [`${commandName} --gameId <id>`] : []),
+    CREATE_GAME_COMMAND,
+  ]
+
+  return {message: NO_GAME_MESSAGE, ref: CREATE_A_PROJECT_DOCS, suggestions}
 }

--- a/src/utils/ship/index.ts
+++ b/src/utils/ship/index.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import {v4 as uuid} from 'uuid'
 
 import {getProject, startJobsFromUpload} from '@cli/api/index.js'
+import {WIZARD_COMMANDS} from '@cli/constants/commands.js'
 import type {Job, Platform, ProjectConfig, ShipGameFlags, UploadDetails} from '@cli/types'
 import {detectGodotVersion, getGodotVersionDrift} from '@cli/utils/godot.js'
 import {getCWDGitInfo, getFileHash} from '@cli/utils/index.js'
@@ -14,7 +15,10 @@ import {MAX_SINGLE_UPLOAD_SIZE, type ProgressData, singleUpload} from './upload.
 import {formatProgressLog, getPlatforms} from './utils.js'
 import {createZip} from './zip.js'
 
-const ERR_NOT_CONFIGURED = 'No Android or iOS configuration found. Please run `shipthis game wizard android` or `shipthis game wizard ios` to configure your game.'
+const ERR_NOT_CONFIGURED =
+  'This game has no Android or iOS configuration.\n' +
+  'Set up a platform with:\n\n' +
+  WIZARD_COMMANDS.map((command) => `  ${command}`).join('\n')
 
 const getVersionMismatch = (detected: string, configured: string) =>
   `Your project.godot targets Godot ${detected}, but this game builds with Godot ${configured}.`

--- a/test/utils/errors.test.ts
+++ b/test/utils/errors.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 
-import {getS3Error, isRetryable} from '@cli/utils/errors.js'
+import {getNoGameError, getS3Error, isRetryable} from '@cli/utils/errors.js'
 
 // The shape Spaces really answers with, taken from a live failed request
 const s3Error = (code: string, message: string) =>
@@ -79,5 +79,58 @@ describe('isRetryable (utils/errors)', () => {
 
     expect(error.code).to.equal(undefined)
     expect(isRetryable(error)).to.equal(true)
+  })
+})
+
+describe('getNoGameError (utils/errors)', () => {
+  it('names both wizards when the command knows no platform', () => {
+    const {suggestions} = getNoGameError('shipthis game status')
+
+    expect(suggestions).to.include('shipthis game wizard android')
+    expect(suggestions).to.include('shipthis game wizard ios')
+  })
+
+  it('names the android wizard alone for --platform android', () => {
+    const {suggestions} = getNoGameError('shipthis game status', 'android')
+
+    expect(suggestions).to.include('shipthis game wizard android')
+    expect(suggestions).to.not.include('shipthis game wizard ios')
+  })
+
+  it('names the iOS wizard alone for --platform ios', () => {
+    const {suggestions} = getNoGameError('shipthis game status', 'ios')
+
+    expect(suggestions).to.include('shipthis game wizard ios')
+    expect(suggestions).to.not.include('shipthis game wizard android')
+  })
+
+  it('names the command the user typed in the --gameId suggestion', () => {
+    const {suggestions} = getNoGameError('shipthis game details')
+
+    expect(suggestions).to.include('shipthis game details --gameId <id>')
+  })
+
+  // `shipthis --gameId <id>` is not a command, so the line goes rather than ships broken.
+  it('drops the --gameId suggestion when there is no command name', () => {
+    const {suggestions} = getNoGameError('')
+
+    expect(suggestions?.some((s) => s.includes('--gameId'))).to.equal(false)
+    expect(suggestions).to.deep.equal([
+      'shipthis game wizard android',
+      'shipthis game wizard ios',
+      'shipthis game create --name "My Game"',
+    ])
+  })
+
+  // The fault issue 252 reports. `shipthis game wizard` alone fails on the missing arg.
+  it('never suggests the wizard without a platform', () => {
+    for (const platform of [undefined, 'android', 'ios']) {
+      const {suggestions} = getNoGameError('shipthis game status', platform)
+      expect(suggestions).to.not.include('shipthis game wizard')
+    }
+  })
+
+  it('points at the docs page for setting a game up', () => {
+    expect(getNoGameError('shipthis game status').ref).to.equal('https://shipth.is/docs/create-a-project')
   })
 })

--- a/test/utils/errors.test.ts
+++ b/test/utils/errors.test.ts
@@ -110,7 +110,7 @@ describe('getNoGameError (utils/errors)', () => {
     expect(suggestions).to.include('shipthis game details --gameId <id>')
   })
 
-  // `shipthis --gameId <id>` is not a command, so the line goes rather than ships broken.
+  // An empty name would build `shipthis --gameId <id>`, which is not a command.
   it('drops the --gameId suggestion when there is no command name', () => {
     const {suggestions} = getNoGameError('')
 
@@ -120,6 +120,25 @@ describe('getNoGameError (utils/errors)', () => {
       'shipthis game wizard ios',
       'shipthis game create --name "My Game"',
     ])
+  })
+
+  // `game ship` needs shipthis.json, so --gameId leads back to this same error.
+  it('drops the --gameId suggestion when the command needs a project config', () => {
+    const {message, suggestions} = getNoGameError('shipthis game ship', undefined, {needsProjectConfig: true})
+
+    expect(suggestions?.some((s) => s.includes('--gameId'))).to.equal(false)
+    expect(message).to.not.include('--gameId')
+    expect(suggestions).to.deep.equal([
+      'shipthis game wizard android',
+      'shipthis game wizard ios',
+      'shipthis game create --name "My Game"',
+    ])
+  })
+
+  it('still narrows the wizard by platform when a project config is needed', () => {
+    const {suggestions} = getNoGameError('shipthis game ship', 'android', {needsProjectConfig: true})
+
+    expect(suggestions).to.deep.equal(['shipthis game wizard android', 'shipthis game create --name "My Game"'])
   })
 
   // The fault issue 252 reports. `shipthis game wizard` alone fails on the missing arg.


### PR DESCRIPTION
This is to resolve #252 

## What's changed

- centralized `getNoGameError` which builds one of the more rich oclif errors with suggestions etc with tests
- When platform is available the recommendations change
- Applied to  `shipthis game status` and other commands via `getGame` and `baseGameCommand`
- `WIZARD_COMMANDS` reused in other commands e.g `game list`

## Output

```bash
david@sal9000:/tmp/t/empty$ st game status
 ›   Error: No game is set up in this directory.
 ›   Run the wizard for the platform you want to ship to, or name a game you already have with 
 ›   --gameId. Run `shipthis game list` to see your game IDs.
 ›   Try this:
 ›     * shipthis game wizard android
 ›     * shipthis game wizard ios
 ›     * shipthis game status --gameId <id>
 ›     * shipthis game create --name "My Game"
 ›   Reference: https://shipth.is/docs/create-a-project
```

```bash
david@sal9000:/tmp/t/godot$ st game ship
 ›   Error: No game is set up in this directory.
 ›   Run the wizard for the platform you want to ship to.
 ›   Try this:
 ›     * shipthis game wizard android
 ›     * shipthis game wizard ios
 ›     * shipthis game create --name "My Game"
 ›   Reference: https://shipth.is/docs/create-a-project
david@sal9000:/tmp/t/godot$ 
```

Also updated when there are no configured platforms for the `ship` command:

```bash
david@sal9000:/tmp/t/fresh$ st game ship

Error: This game has no Android or iOS configuration.
Set up a platform with:

  shipthis game wizard android
  shipthis game wizard ios
david@sal9000:/tmp/t/fresh$ 
```

I have manually tested all the affected commands