### PR TITLE
fix: workaround for "iTunes Service Key is empty"

### DIFF
--- a/src/commands/apple/login.ts
+++ b/src/commands/apple/login.ts
@@ -12,6 +12,12 @@ const {Auth} = appleUtils
 
 const SOURCE_URL = 'https://github.com/shipth-is/cli/blob/main/src/commands/apple/login.ts'
 
+// TODO: remove once Apple's config endpoint works again, or @expo/apple-utils stops needing it.
+// That endpoint has 404'd since 2026-09-11, which surfaces as "iTunes service key is empty"
+// (expo/eas-cli#4392, fastlane/fastlane#30199). Not a secret - App Store Connect sends the same
+// value as X-Apple-Widget-Key.
+const APPLE_SERVICE_KEY = 'e0b80c3bf78523bfe80974d320935bfa30add02e1bff88ec2166c6bd5a706c42'
+
 export default class AppleLogin extends BaseAuthenticatedCommand<typeof AppleLogin> {
   static override args = {}
 
@@ -37,6 +43,11 @@ Your Apple password is sent only to Apple, never to ShipThis. Only the resulting
 
   public async run(): Promise<void> {
     const {flags} = this
+
+    // Only set if unset, so it can still be overridden from the environment.
+    if (!process.env.EXPO_APP_STORE_AUTH_SERVICE_KEY) {
+      process.env.EXPO_APP_STORE_AUTH_SERVICE_KEY = APPLE_SERVICE_KEY
+    }
 
     if (flags.logout) {
       await this.setAppleCookies(undefined)


### PR DESCRIPTION
Workaround for #263 - forcing EXPO_APP_STORE_AUTH_SERVICE_KEY

## What's changed

- Forcing EXPO_APP_STORE_AUTH_SERVICE_KEY env var to be the value from [the ](https://github.com/expo/eas-cli/issues/4392#issuecomment-5641010175)
- Will remove once resolved by Apple or upstream (expo)

### Example

Users will see an extra `Using iTunes service key from environment: e0b80c3bf78523bfe80974d320935bfa30add02e1bff88ec2166c6bd5a706c42` in the output

```bash
david@sal9000:~/game$ shipthis apple login
# Signing in to Apple

ShipThis sends your Apple ID and password directly to Apple's authentication service, using the open-source @expo/apple-utils library.

    * Your password is never stored and is never sent to ShipThis servers.
    * Only the resulting Apple session cookies are saved, locally, to your auth file.
    * Your password is used once, for this sign-in, and then discarded.

Read the exact code that handles your password: https://github.com/shipth-is/cli/blob/v0.1.58/src/commands/apple/login.ts
Please enter your Apple Developer account email address: xxx@xxx.com
Please enter your Apple Developer password: *********************
Using iTunes service key from environment: e0b80c3bf78523bfe80974d320935bfa30add02e1bff88ec2166c6bd5a706c42
✔ Logged in, verify your Apple account to continue
Two-factor Authentication (6 digit code) is enabled for xxx@xxx.com. Learn more.

✔ Please enter the 6 digit code you received at +44 ••••• ••••40: … XXXXXX
✔ Valid code
✔ Logged in and verified
› Team Hello Invent Ltd (G96W73MSVM)
› Provider Hello Invent Ltd (118356409)
› Restoring session cookies
› Team Hello Invent Ltd (G96W73MSVM)
› Provider Hello Invent Ltd (118356409)
✔ Logged in Cookies
APPLE STATUS
  Apple Full Name                          David Sutherland
  Apple Provider Name                      Hello Invent Ltd
  Authenticated on Apple Developer Portal  YES

david@sal9000:~/game$ 
```